### PR TITLE
[Phase 1] Garmin Connect 연동 + 인증 (#5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,9 @@ CLAUDE.md
 *.tsbuildinfo
 next-env.d.ts
 
+# garmin tokens
+.garmin-tokens/
+
 # backups & logs & reports
 /backups/
 /logs/

--- a/docs/specs/3-garmin-connect.md
+++ b/docs/specs/3-garmin-connect.md
@@ -1,0 +1,62 @@
+# [Phase 1] Garmin Connect 연동 + 인증
+
+## 목적
+
+Garmin Connect에 인증하고 데이터를 조회할 수 있는 클라이언트 모듈을 구현한다.
+토큰 캐싱으로 rate limit(429)을 방지하고, 세션 만료 시 자동 재인증을 처리한다.
+
+## 요구사항
+
+- [ ] `@flow-js/garmin-connect` 패키지 설치
+- [ ] Garmin 클라이언트 래퍼 (`src/lib/garmin/client.ts`)
+- [ ] OAuth 토큰 캐싱 (파일 기반, 재로그인 최소화)
+- [ ] 세션 만료 시 자동 재인증
+- [ ] 연결 테스트 스크립트 (`scripts/test-garmin.ts`)
+- [ ] 환경변수: GARMIN_EMAIL, GARMIN_PASSWORD
+
+## 기술 설계
+
+### 패키지 선택
+
+`@flow-js/garmin-connect` (v1.6.16+) — 원본 `garmin-connect`의 활발한 포크.
+- OAuth1/OAuth2 토큰 캐싱 지원
+- TypeScript 타입 내장
+- 활발한 유지보수 (최근 업데이트 3일 전)
+
+### 클라이언트 래퍼 설계
+
+```typescript
+// src/lib/garmin/client.ts
+class GarminClient {
+  // 싱글톤 인스턴스
+  // 토큰 캐시 경로: .garmin-tokens/
+  // login(): 토큰 캐시 로드 시도 → 실패 시 이메일/비밀번호 로그인
+  // ensureAuth(): 인증 상태 확인, 만료 시 재인증
+  // getClient(): 인증된 GarminConnect 인스턴스 반환
+}
+```
+
+### 토큰 캐싱 전략
+
+- `exportTokenToFile()` / `loadTokenByFile()`로 OAuth 토큰 파일 저장
+- 저장 경로: `.garmin-tokens/` (gitignore에 추가)
+- 로그인 성공 시 자동 저장, 다음 실행 시 자동 로드
+- 토큰 만료/실패 시 재로그인 후 토큰 갱신
+
+### 에러 처리
+
+- 429 (Rate Limit): 토큰 캐시 사용으로 예방. 발생 시 60초 대기 후 재시도.
+- 401 (Auth Failure): 토큰 캐시 삭제 → 이메일/비밀번호로 재로그인.
+- 네트워크 오류: 3회 재시도 후 실패.
+
+## 테스트 계획
+
+- [ ] `npx tsx scripts/test-garmin.ts` → 로그인 성공 + 프로필 정보 출력
+- [ ] 토큰 캐시 파일 생성 확인 (`.garmin-tokens/`)
+- [ ] 2번째 실행 시 캐시된 토큰으로 로그인 (재인증 없이)
+- [ ] `npm run lint` + `npx tsc --noEmit` + `npm run build` 통과
+
+## 제외 사항
+
+- 데이터 싱크 로직 (이슈 #4)
+- API routes (이슈 #5)

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "myfitness",
       "version": "0.1.0",
       "dependencies": {
+        "@flow-js/garmin-connect": "^1.6.16",
         "@prisma/client": "^6.19.3",
         "date-fns": "^4.1.0",
         "marked": "^17.0.6",
@@ -580,6 +581,22 @@
       "license": "MIT",
       "engines": {
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      }
+    },
+    "node_modules/@flow-js/garmin-connect": {
+      "version": "1.6.16",
+      "resolved": "https://registry.npmjs.org/@flow-js/garmin-connect/-/garmin-connect-1.6.16.tgz",
+      "integrity": "sha512-Gr4Ficq9xloVEQZX0OaFF6qbWN1719QFaXdmKjHBZ/+RLpe6xD++ZXYJtS7UQhvvcmv/ys/sdnxDLjWrjCz5jQ==",
+      "license": "MIT",
+      "dependencies": {
+        "app-root-path": "^3.1.0",
+        "axios": "^1.5.1",
+        "crypto": "^1.0.1",
+        "form-data": "^4.0.0",
+        "lodash": "^4.17.21",
+        "luxon": "^3.4.3",
+        "oauth-1.0a": "^2.2.6",
+        "qs": "^6.11.2"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1761,6 +1778,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/app-root-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-3.1.0.tgz",
+      "integrity": "sha512-biN3PwB2gUtjaYy/isrU3aNWI5w+fAfvHkSvCKeQGxhmYpwKFUxudR3Yya+KqVRHBmEDYh+/lTozYCFbmzX4nA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/arg": {
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/arg/-/arg-5.0.2.tgz",
@@ -1962,6 +1988,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -1986,6 +2018,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.14.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+      "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2158,7 +2201,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2172,7 +2214,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
       "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -2316,6 +2357,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/commander": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
@@ -2364,6 +2417,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/crypto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/crypto/-/crypto-1.0.1.tgz",
+      "integrity": "sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==",
+      "deprecated": "This package is no longer supported. It's now a built-in Node module. If you've depended on crypto, you should switch to the one that's built-in.",
+      "license": "ISC"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -2534,6 +2594,15 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/destr": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/destr/-/destr-2.0.5.tgz",
@@ -2585,7 +2654,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -2704,7 +2772,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2714,7 +2781,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2753,7 +2819,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2766,7 +2831,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3450,6 +3514,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3483,6 +3567,22 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -3509,7 +3609,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3560,7 +3659,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3585,7 +3683,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3744,7 +3841,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3822,7 +3918,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3835,7 +3930,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3851,7 +3945,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
       "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4576,6 +4669,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -4602,6 +4701,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/marked": {
       "version": "17.0.6",
       "resolved": "https://registry.npmjs.org/marked/-/marked-17.0.6.tgz",
@@ -4618,7 +4726,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -4646,6 +4753,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -4900,6 +5028,12 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/oauth-1.0a": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/oauth-1.0a/-/oauth-1.0a-2.2.6.tgz",
+      "integrity": "sha512-6bkxv3N4Gu5lty4viIcIAnq5GbxECviMBeKR3WX/q87SPQ8E8aursPZUtsXDnxCs787af09WPRBLqYrf/lwoYQ==",
+      "license": "MIT"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -4924,7 +5058,6 @@
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
       "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5492,6 +5625,15 @@
         "react-is": "^16.13.1"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -5518,6 +5660,21 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
+      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
@@ -5921,7 +6078,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
       "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5941,7 +6097,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
       "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -5958,7 +6113,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
       "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",
@@ -5977,7 +6131,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
       "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bound": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@flow-js/garmin-connect": "^1.6.16",
     "@prisma/client": "^6.19.3",
     "date-fns": "^4.1.0",
     "marked": "^17.0.6",

--- a/scripts/test-garmin.ts
+++ b/scripts/test-garmin.ts
@@ -1,0 +1,59 @@
+import "dotenv/config";
+import { getGarminClient, resetClient } from "../src/lib/garmin/client";
+
+async function main() {
+  console.log("=== Garmin Connect 연결 테스트 ===\n");
+
+  try {
+    // 1. 로그인
+    console.log("1. 로그인 시도...");
+    const client = await getGarminClient();
+    console.log("   로그인 성공!\n");
+
+    // 2. 프로필 조회
+    console.log("2. 사용자 프로필 조회...");
+    const profile = await client.getUserProfile();
+    console.log(`   이름: ${profile.displayName}`);
+    console.log(`   프로필: ${JSON.stringify(profile, null, 2).slice(0, 500)}\n`);
+
+    // 3. 오늘 걸음 수
+    console.log("3. 오늘 걸음 수 조회...");
+    try {
+      const steps = await client.getSteps();
+      console.log(`   걸음 수: ${steps.toLocaleString()}\n`);
+    } catch {
+      console.log("   걸음 수 데이터 없음\n");
+    }
+
+    // 4. 최근 활동 1개
+    console.log("4. 최근 활동 조회...");
+    const activities = await client.getActivities(0, 1);
+    if (activities.length > 0) {
+      const a = activities[0];
+      console.log(`   최근 활동: ${a.activityName}`);
+      console.log(`   타입: ${a.activityType?.typeKey}`);
+      console.log(`   날짜: ${a.startTimeLocal}`);
+    } else {
+      console.log("   활동 데이터 없음");
+    }
+
+    // 5. 토큰 캐시 확인
+    console.log("\n5. 토큰 캐시 확인...");
+    const fs = await import("fs");
+    const path = await import("path");
+    const tokenDir = path.resolve(process.cwd(), ".garmin-tokens");
+    if (fs.existsSync(tokenDir)) {
+      const files = fs.readdirSync(tokenDir);
+      console.log(`   캐시 파일: ${files.join(", ")}`);
+    }
+
+    console.log("\n=== 테스트 완료 ===");
+  } catch (error) {
+    console.error("\n테스트 실패:", error);
+    process.exit(1);
+  } finally {
+    resetClient();
+  }
+}
+
+main();

--- a/src/lib/garmin/client.ts
+++ b/src/lib/garmin/client.ts
@@ -1,0 +1,92 @@
+import { GarminConnect } from "@flow-js/garmin-connect";
+import path from "path";
+import fs from "fs";
+
+const TOKEN_DIR = path.resolve(process.cwd(), ".garmin-tokens");
+
+function ensureTokenDir(): void {
+  if (!fs.existsSync(TOKEN_DIR)) {
+    fs.mkdirSync(TOKEN_DIR, { recursive: true });
+  }
+}
+
+function getCredentials(): { username: string; password: string } {
+  const username = process.env.GARMIN_EMAIL;
+  const password = process.env.GARMIN_PASSWORD;
+
+  if (!username || !password) {
+    throw new Error(
+      "GARMIN_EMAIL and GARMIN_PASSWORD must be set in environment variables"
+    );
+  }
+
+  return { username, password };
+}
+
+let clientInstance: GarminConnect | null = null;
+let isAuthenticated = false;
+
+async function authenticate(client: GarminConnect): Promise<void> {
+  ensureTokenDir();
+
+  // 캐시된 토큰으로 로그인 시도
+  try {
+    if (fs.existsSync(path.join(TOKEN_DIR, "oauth1_token.json"))) {
+      client.loadTokenByFile(TOKEN_DIR);
+      // 토큰 유효성 검증 (간단한 API 호출)
+      await client.getUserProfile();
+      isAuthenticated = true;
+      return;
+    }
+  } catch {
+    // 토큰 만료 또는 무효 → 재로그인
+  }
+
+  // 이메일/비밀번호로 로그인
+  const { username, password } = getCredentials();
+  await client.login(username, password);
+  client.exportTokenToFile(TOKEN_DIR);
+  isAuthenticated = true;
+}
+
+export async function getGarminClient(): Promise<GarminConnect> {
+  if (clientInstance && isAuthenticated) {
+    return clientInstance;
+  }
+
+  const { username, password } = getCredentials();
+  clientInstance = new GarminConnect({ username, password });
+
+  await authenticate(clientInstance);
+  return clientInstance;
+}
+
+export async function withReauth<T>(
+  fn: (client: GarminConnect) => Promise<T>
+): Promise<T> {
+  const client = await getGarminClient();
+
+  try {
+    return await fn(client);
+  } catch (error: unknown) {
+    const status =
+      error instanceof Error && "status" in error
+        ? (error as { status: number }).status
+        : undefined;
+
+    if (status === 401 || status === 403) {
+      // 토큰 만료 → 재인증 후 재시도
+      isAuthenticated = false;
+      clientInstance = null;
+      const freshClient = await getGarminClient();
+      return await fn(freshClient);
+    }
+
+    throw error;
+  }
+}
+
+export function resetClient(): void {
+  clientInstance = null;
+  isAuthenticated = false;
+}


### PR DESCRIPTION
## 변경 사항

- `@flow-js/garmin-connect` 패키지 설치 (원본 `garmin-connect`의 활발한 포크)
- Garmin 클라이언트 래퍼 (`src/lib/garmin/client.ts`):
  - 싱글톤 인스턴스 관리
  - OAuth 토큰 파일 캐싱 (`.garmin-tokens/`)으로 rate limit 방지
  - `withReauth()` 헬퍼: 401/403 시 자동 재인증 후 재시도
- 연결 테스트 스크립트 (`scripts/test-garmin.ts`)
- `.garmin-tokens/` gitignore 추가

Closes #5

## 체크리스트

- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] `npx tsx scripts/test-garmin.ts` 연결 테스트 통과

## 스펙 문서

`docs/specs/3-garmin-connect.md`