### PR TITLE
[Phase 1] Garmin 데이터 싱크 엔진 (#8)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,8 +5,8 @@
 프로젝트 셋업, DB, Garmin 연결, 데이터 싱크.
 
 - [x] #1 프로젝트 초기화 + PM2 배포 설정
-- [ ] #2 DB 스키마 설계 + Prisma 마이그레이션
-- [ ] #3 Garmin Connect 연동 + 인증
+- [x] #2 DB 스키마 설계 + Prisma 마이그레이션
+- [x] #3 Garmin Connect 연동 + 인증
 - [ ] #4 Garmin 데이터 싱크 엔진 (365일 히스토리)
 - [ ] #5 수동 싱크 API + 싱크 상태 관리
 

--- a/docs/specs/4-garmin-sync-engine.md
+++ b/docs/specs/4-garmin-sync-engine.md
@@ -1,0 +1,75 @@
+# [Phase 1] Garmin 데이터 싱크 엔진
+
+## 목적
+
+Garmin Connect에서 데이터를 가져와 DB에 저장하는 싱크 엔진 구현.
+초기 365일 히스토리 로드와 증분 싱크를 모두 지원한다.
+
+## 요구사항
+
+- [ ] 데이터 타입별 fetcher (활동, 일별 요약, 수면, 심박, 체성분)
+- [ ] 싱크 오케스트레이터 (전체 싱크 흐름 관리)
+- [ ] API 호출 간 2초 딜레이 (rate limit 방지)
+- [ ] SyncMetadata 추적 (타입별 마지막 싱크 날짜, 상태)
+- [ ] 초기 로드: 365일 히스토리
+- [ ] 증분 싱크: lastSyncDate 이후 ~ 어제까지
+- [ ] upsert 패턴 (중복 방지)
+- [ ] 데이터 타입별 독립 싱크 (하나 실패해도 나머지 진행)
+- [ ] 싱크 테스트 스크립트
+
+## 기술 설계
+
+### 싱크 순서
+
+1. DailySummary (가장 가벼움, 대시보드 즉시 활용)
+2. Activity (핵심 운동 데이터)
+3. SleepRecord (수면 분석)
+4. HeartRateRecord (심박/HRV 트렌드)
+5. BodyComposition (체중 측정, 빈도 낮음)
+
+### fetcher 구조
+
+```
+src/lib/garmin/
+├── client.ts          # (기존) 인증 + 클라이언트 래퍼
+├── sync.ts            # 싱크 오케스트레이터
+└── fetchers/
+    ├── activities.ts
+    ├── daily-summary.ts
+    ├── sleep.ts
+    ├── heart-rate.ts
+    └── body-composition.ts
+```
+
+### 각 fetcher 패턴
+
+```typescript
+async function syncActivities(startDate: Date, endDate: Date): Promise<number>
+// 1. Garmin API 호출 (날짜별 또는 페이지네이션)
+// 2. 데이터 파싱 (Garmin 응답 → Prisma 모델)
+// 3. upsert (garminId 또는 date 기준)
+// 4. 건수 반환
+```
+
+### rate limit
+
+- `delay(ms)` 유틸: 호출 간 2초 대기
+- API 호출 단위로 적용 (날짜별 또는 페이지별)
+
+### SyncMetadata 관리
+
+- 싱크 시작: status → "syncing"
+- 싱크 완료: status → "idle", lastSyncDate 업데이트, syncCount++
+- 싱크 실패: status → "error", errorMessage 기록
+
+## 테스트 계획
+
+- [ ] `npx tsx scripts/sync-garmin.ts` → 전체 데이터 타입 싱크 실행
+- [ ] DB에 데이터 적재 확인 (`npx prisma studio`)
+- [ ] SyncMetadata 레코드 생성 확인
+- [ ] `npm run lint` + `npx tsc --noEmit` + `npm run build` 통과
+
+## 제외 사항
+
+- API route (이슈 #5)
+- Cron 자동 싱크 (Phase 3, 이슈 #11)

--- a/scripts/sync-garmin.ts
+++ b/scripts/sync-garmin.ts
@@ -1,0 +1,50 @@
+import "dotenv/config";
+import { getGarminClient, resetClient } from "../src/lib/garmin/client";
+import { syncAll } from "../src/lib/garmin/sync";
+
+async function main() {
+  const args = process.argv.slice(2);
+  const daysFlag = args.find((a) => a.startsWith("--days="));
+  const days = daysFlag ? parseInt(daysFlag.split("=")[1]) : undefined;
+
+  console.log("=== Garmin 데이터 싱크 ===\n");
+
+  // 연결 확인
+  console.log("1. Garmin Connect 로그인...");
+  await getGarminClient();
+  console.log("   로그인 성공!\n");
+
+  // 싱크 실행
+  console.log("2. 데이터 싱크 시작...\n");
+
+  const options = days
+    ? {
+        startDate: (() => {
+          const d = new Date();
+          d.setDate(d.getDate() - days);
+          d.setHours(0, 0, 0, 0);
+          return d;
+        })(),
+      }
+    : undefined;
+
+  const results = await syncAll(options);
+
+  // 결과 요약
+  console.log("\n=== 싱크 결과 ===");
+  for (const r of results) {
+    const status = r.error ? `실패: ${r.error}` : `${r.synced}건`;
+    console.log(`  ${r.dataType}: ${status}`);
+  }
+
+  const total = results.reduce((sum, r) => sum + r.synced, 0);
+  const failed = results.filter((r) => r.error).length;
+  console.log(`\n총 ${total}건 싱크, ${failed}건 실패`);
+
+  resetClient();
+}
+
+main().catch((error) => {
+  console.error("싱크 실패:", error);
+  process.exit(1);
+});

--- a/src/lib/garmin/fetchers/activities.ts
+++ b/src/lib/garmin/fetchers/activities.ts
@@ -1,0 +1,76 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { withRateLimit } from "../utils";
+
+const PAGE_SIZE = 20;
+
+export async function syncActivities(
+  client: GarminConnect,
+  startDate: Date,
+  endDate: Date
+): Promise<number> {
+  let synced = 0;
+  let start = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const activities = await withRateLimit(() =>
+      client.getActivities(start, PAGE_SIZE)
+    );
+
+    if (activities.length === 0) {
+      hasMore = false;
+      break;
+    }
+
+    for (const a of activities) {
+      const activityDate = new Date(a.startTimeLocal || a.startTimeGMT);
+
+      if (activityDate < startDate) {
+        hasMore = false;
+        break;
+      }
+
+      if (activityDate > endDate) {
+        continue;
+      }
+
+      // IActivity 타입에 없는 필드는 any 캐스팅
+      const raw = a as unknown as Record<string, unknown>;
+      const summaryDTO = raw.summaryDTO as Record<string, unknown> | undefined;
+
+      const data = {
+        activityType: a.activityType?.typeKey ?? "unknown",
+        name: a.activityName ?? "Untitled",
+        startTime: activityDate,
+        duration: Math.round(a.duration ?? 0),
+        distance: a.distance ?? null,
+        calories: a.calories ? Math.round(a.calories) : null,
+        avgHR: a.averageHR ? Math.round(a.averageHR) : null,
+        maxHR: a.maxHR ? Math.round(a.maxHR) : null,
+        avgPace:
+          a.distance && a.duration && a.distance > 0
+            ? a.duration / (a.distance / 1000)
+            : null,
+        avgSpeed: a.averageSpeed ? a.averageSpeed * 3.6 : null,
+        elevationGain: a.elevationGain ?? null,
+        trainingEffect: (summaryDTO?.trainingEffect as number) ?? null,
+        vo2maxEstimate: (raw.vO2MaxValue as number) ?? null,
+        rawData: raw as Prisma.InputJsonValue,
+      };
+
+      await prisma.activity.upsert({
+        where: { garminId: BigInt(a.activityId) },
+        update: data,
+        create: { garminId: BigInt(a.activityId), ...data },
+      });
+
+      synced++;
+    }
+
+    start += PAGE_SIZE;
+  }
+
+  return synced;
+}

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { dateRange, startOfDay, withRateLimit } from "../utils";
+import { dateRange, isNoDataError, startOfDay, withRateLimit } from "../utils";
 
 export async function syncBodyComposition(
   client: GarminConnect,
@@ -41,8 +41,9 @@ export async function syncBodyComposition(
       });
 
       synced++;
-    } catch {
-      // 해당 날짜 체중 데이터 없음 → 건너뜀
+    } catch (error) {
+      if (isNoDataError(error)) continue;
+      throw error;
     }
   }
 

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -1,0 +1,65 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { dateRange, startOfDay, withRateLimit } from "../utils";
+
+export async function syncBodyComposition(
+  client: GarminConnect,
+  startDate: Date,
+  endDate: Date
+): Promise<number> {
+  let synced = 0;
+  const dates = dateRange(startDate, endDate);
+
+  for (const date of dates) {
+    try {
+      const weightData = await withRateLimit(() =>
+        client.getDailyWeightData(date)
+      );
+
+      if (!weightData) continue;
+
+      const raw = weightData as unknown as Record<string, unknown>;
+      const weight = extractWeight(raw);
+
+      if (weight === null) continue;
+
+      const dayDate = startOfDay(date);
+
+      const data = {
+        weight,
+        bmi: toFloat(raw.bmi),
+        bodyFat: toFloat(raw.bodyFat),
+        muscleMass: toFloat(raw.muscleMass),
+        rawData: raw as Prisma.InputJsonValue,
+      };
+
+      await prisma.bodyComposition.upsert({
+        where: { date: dayDate },
+        update: data,
+        create: { date: dayDate, ...data },
+      });
+
+      synced++;
+    } catch {
+      // 해당 날짜 체중 데이터 없음 → 건너뜀
+    }
+  }
+
+  return synced;
+}
+
+function toFloat(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : n;
+}
+
+function extractWeight(raw: Record<string, unknown>): number | null {
+  const w = raw.weight as number | undefined;
+  if (w === null || w === undefined) return null;
+
+  // 1000 이상이면 gram → kg 변환
+  if (w > 1000) return Math.round((w / 1000) * 10) / 10;
+  return Math.round(w * 10) / 10;
+}

--- a/src/lib/garmin/fetchers/daily-summary.ts
+++ b/src/lib/garmin/fetchers/daily-summary.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { dateRange, startOfDay, withRateLimit } from "../utils";
+import { dateRange, formatDate, isNoDataError, startOfDay, withRateLimit } from "../utils";
 
 export async function syncDailySummaries(
   client: GarminConnect,
@@ -13,7 +13,7 @@ export async function syncDailySummaries(
 
   for (const date of dates) {
     try {
-      const dateStr = date.toISOString().split("T")[0];
+      const dateStr = formatDate(date);
       const summary = await withRateLimit(() =>
         client.get<Record<string, unknown>>(
           `https://connect.garmin.com/usersummary-service/usersummary/daily/${dateStr}`
@@ -51,8 +51,9 @@ export async function syncDailySummaries(
       });
 
       synced++;
-    } catch {
-      // 해당 날짜 데이터 없음 → 건너뜀
+    } catch (error) {
+      if (isNoDataError(error)) continue;
+      throw error;
     }
   }
 

--- a/src/lib/garmin/fetchers/daily-summary.ts
+++ b/src/lib/garmin/fetchers/daily-summary.ts
@@ -1,0 +1,66 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { dateRange, startOfDay, withRateLimit } from "../utils";
+
+export async function syncDailySummaries(
+  client: GarminConnect,
+  startDate: Date,
+  endDate: Date
+): Promise<number> {
+  let synced = 0;
+  const dates = dateRange(startDate, endDate);
+
+  for (const date of dates) {
+    try {
+      const dateStr = date.toISOString().split("T")[0];
+      const summary = await withRateLimit(() =>
+        client.get<Record<string, unknown>>(
+          `https://connect.garmin.com/usersummary-service/usersummary/daily/${dateStr}`
+        )
+      );
+
+      if (!summary) continue;
+
+      const dayDate = startOfDay(date);
+      const moderate = toInt(summary.moderateIntensityMinutes);
+      const vigorous = toInt(summary.vigorousIntensityMinutes);
+      const intensityMin =
+        moderate !== null || vigorous !== null
+          ? (moderate ?? 0) + (vigorous ?? 0)
+          : null;
+
+      const data = {
+        steps: toInt(summary.totalSteps),
+        totalCalories: toInt(summary.totalKilocalories),
+        activeCalories: toInt(summary.activeKilocalories),
+        restingHR: toInt(summary.restingHeartRate),
+        avgStress: toInt(summary.averageStressLevel),
+        bodyBattery: toInt(summary.bodyBatteryMostRecentValue),
+        bodyBatteryHigh: toInt(summary.bodyBatteryHighestValue),
+        bodyBatteryLow: toInt(summary.bodyBatteryLowestValue),
+        intensityMin,
+        floorsClimbed: toInt(summary.floorsAscended),
+        rawData: summary as Prisma.InputJsonValue,
+      };
+
+      await prisma.dailySummary.upsert({
+        where: { date: dayDate },
+        update: data,
+        create: { date: dayDate, ...data },
+      });
+
+      synced++;
+    } catch {
+      // 해당 날짜 데이터 없음 → 건너뜀
+    }
+  }
+
+  return synced;
+}
+
+function toInt(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : Math.round(n);
+}

--- a/src/lib/garmin/fetchers/heart-rate.ts
+++ b/src/lib/garmin/fetchers/heart-rate.ts
@@ -1,0 +1,75 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { dateRange, startOfDay, withRateLimit } from "../utils";
+
+export async function syncHeartRate(
+  client: GarminConnect,
+  startDate: Date,
+  endDate: Date
+): Promise<number> {
+  let synced = 0;
+  const dates = dateRange(startDate, endDate);
+
+  for (const date of dates) {
+    try {
+      const hrData = await withRateLimit(() => client.getHeartRate(date));
+
+      if (!hrData) continue;
+
+      const raw = hrData as unknown as Record<string, unknown>;
+      const dayDate = startOfDay(date);
+
+      // getSleepData에서 HRV 정보 가져옴
+      let hrvStatus: number | null = null;
+      try {
+        const sleepData = await client.getSleepData(date);
+        hrvStatus = sleepData?.avgOvernightHrv ?? null;
+      } catch {
+        // HRV 데이터 없음
+      }
+
+      const data = {
+        restingHR: toInt(raw.restingHeartRate),
+        avgHR: extractAvgHR(raw),
+        maxHR: toInt(raw.maxHeartRate),
+        minHR: toInt(raw.minHeartRate),
+        hrvStatus,
+        hrvBaseline: null as number | null,
+        rawData: raw as Prisma.InputJsonValue,
+      };
+
+      await prisma.heartRateRecord.upsert({
+        where: { date: dayDate },
+        update: data,
+        create: { date: dayDate, ...data },
+      });
+
+      synced++;
+    } catch {
+      // 해당 날짜 심박 데이터 없음 → 건너뜀
+    }
+  }
+
+  return synced;
+}
+
+function toInt(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : Math.round(n);
+}
+
+function extractAvgHR(raw: Record<string, unknown>): number | null {
+  const values = raw.heartRateValues as Array<[number, number]> | undefined;
+  if (!values || values.length === 0) return null;
+
+  const validValues = values
+    .map(([, hr]) => hr)
+    .filter((hr) => hr > 0);
+
+  if (validValues.length === 0) return null;
+
+  const sum = validValues.reduce((acc, hr) => acc + hr, 0);
+  return Math.round(sum / validValues.length);
+}

--- a/src/lib/garmin/fetchers/heart-rate.ts
+++ b/src/lib/garmin/fetchers/heart-rate.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { dateRange, startOfDay, withRateLimit } from "../utils";
+import { dateRange, isNoDataError, startOfDay, withRateLimit } from "../utils";
 
 export async function syncHeartRate(
   client: GarminConnect,
@@ -46,8 +46,9 @@ export async function syncHeartRate(
       });
 
       synced++;
-    } catch {
-      // 해당 날짜 심박 데이터 없음 → 건너뜀
+    } catch (error) {
+      if (isNoDataError(error)) continue;
+      throw error;
     }
   }
 

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -1,0 +1,60 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import type { Prisma } from "@/generated/prisma/client";
+import prisma from "@/lib/prisma";
+import { dateRange, startOfDay, withRateLimit } from "../utils";
+
+export async function syncSleep(
+  client: GarminConnect,
+  startDate: Date,
+  endDate: Date
+): Promise<number> {
+  let synced = 0;
+  const dates = dateRange(startDate, endDate);
+
+  for (const date of dates) {
+    try {
+      const sleepData = await withRateLimit(() => client.getSleepData(date));
+
+      if (!sleepData?.dailySleepDTO) continue;
+
+      const dto = sleepData.dailySleepDTO;
+
+      if (!dto.sleepStartTimestampLocal || !dto.sleepEndTimestampLocal) continue;
+
+      const dayDate = startOfDay(date);
+
+      const data = {
+        sleepStart: new Date(dto.sleepStartTimestampLocal),
+        sleepEnd: new Date(dto.sleepEndTimestampLocal),
+        totalSleep: Math.round(dto.sleepTimeSeconds / 60),
+        deepSleep: dto.deepSleepSeconds
+          ? Math.round(dto.deepSleepSeconds / 60)
+          : null,
+        lightSleep: dto.lightSleepSeconds
+          ? Math.round(dto.lightSleepSeconds / 60)
+          : null,
+        remSleep: dto.remSleepSeconds
+          ? Math.round(dto.remSleepSeconds / 60)
+          : null,
+        awakeDuration: dto.awakeSleepSeconds
+          ? Math.round(dto.awakeSleepSeconds / 60)
+          : null,
+        sleepScore: dto.sleepScores?.overall?.value ?? null,
+        avgSpO2: null as number | null,
+        rawData: sleepData as unknown as Prisma.InputJsonValue,
+      };
+
+      await prisma.sleepRecord.upsert({
+        where: { date: dayDate },
+        update: data,
+        create: { date: dayDate, ...data },
+      });
+
+      synced++;
+    } catch {
+      // 해당 날짜 수면 데이터 없음 → 건너뜀
+    }
+  }
+
+  return synced;
+}

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { dateRange, startOfDay, withRateLimit } from "../utils";
+import { dateRange, isNoDataError, startOfDay, withRateLimit } from "../utils";
 
 export async function syncSleep(
   client: GarminConnect,
@@ -51,8 +51,9 @@ export async function syncSleep(
       });
 
       synced++;
-    } catch {
-      // 해당 날짜 수면 데이터 없음 → 건너뜀
+    } catch (error) {
+      if (isNoDataError(error)) continue;
+      throw error;
     }
   }
 

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -1,0 +1,149 @@
+import type { GarminConnect } from "@flow-js/garmin-connect";
+import prisma from "@/lib/prisma";
+import { withReauth } from "./client";
+import { daysAgo, yesterday } from "./utils";
+import { syncActivities } from "./fetchers/activities";
+import { syncDailySummaries } from "./fetchers/daily-summary";
+import { syncSleep } from "./fetchers/sleep";
+import { syncHeartRate } from "./fetchers/heart-rate";
+import { syncBodyComposition } from "./fetchers/body-composition";
+
+const INITIAL_HISTORY_DAYS = 365;
+
+type DataType =
+  | "daily_stats"
+  | "activities"
+  | "sleep"
+  | "heart_rate"
+  | "body_composition";
+
+interface SyncResult {
+  dataType: DataType;
+  synced: number;
+  error?: string;
+}
+
+const SYNC_FNS: Record<
+  DataType,
+  (client: GarminConnect, start: Date, end: Date) => Promise<number>
+> = {
+  daily_stats: syncDailySummaries,
+  activities: syncActivities,
+  sleep: syncSleep,
+  heart_rate: syncHeartRate,
+  body_composition: syncBodyComposition,
+};
+
+const SYNC_ORDER: DataType[] = [
+  "daily_stats",
+  "activities",
+  "sleep",
+  "heart_rate",
+  "body_composition",
+];
+
+async function getStartDate(dataType: DataType): Promise<Date> {
+  const meta = await prisma.syncMetadata.findUnique({
+    where: { dataType },
+  });
+
+  if (meta?.lastSyncDate) {
+    // 마지막 싱크 날짜 다음 날부터
+    const next = new Date(meta.lastSyncDate);
+    next.setDate(next.getDate() + 1);
+    return next;
+  }
+
+  // 초기 로드: 365일 전부터
+  return daysAgo(INITIAL_HISTORY_DAYS);
+}
+
+async function updateSyncMetadata(
+  dataType: DataType,
+  endDate: Date,
+  syncCount: number,
+  error?: string
+): Promise<void> {
+  const now = new Date();
+
+  await prisma.syncMetadata.upsert({
+    where: { dataType },
+    update: {
+      lastSyncAt: now,
+      lastSyncDate: endDate,
+      syncCount: { increment: syncCount },
+      status: error ? "error" : "idle",
+      errorMessage: error ?? null,
+    },
+    create: {
+      dataType,
+      lastSyncAt: now,
+      lastSyncDate: endDate,
+      syncCount,
+      status: error ? "error" : "idle",
+      errorMessage: error ?? null,
+    },
+  });
+}
+
+async function markSyncing(dataType: DataType): Promise<void> {
+  await prisma.syncMetadata.upsert({
+    where: { dataType },
+    update: { status: "syncing", errorMessage: null },
+    create: {
+      dataType,
+      lastSyncAt: new Date(),
+      lastSyncDate: new Date(0),
+      status: "syncing",
+    },
+  });
+}
+
+export async function syncAll(
+  options?: {
+    startDate?: Date;
+    endDate?: Date;
+    dataTypes?: DataType[];
+  }
+): Promise<SyncResult[]> {
+  const endDate = options?.endDate ?? yesterday();
+  const dataTypes = options?.dataTypes ?? SYNC_ORDER;
+  const results: SyncResult[] = [];
+
+  for (const dataType of dataTypes) {
+    const startDate = options?.startDate ?? (await getStartDate(dataType));
+
+    if (startDate > endDate) {
+      console.log(`[${dataType}] 이미 최신 상태 (${startDate.toISOString().split("T")[0]}까지 싱크 완료)`);
+      results.push({ dataType, synced: 0 });
+      continue;
+    }
+
+    console.log(
+      `[${dataType}] 싱크 시작: ${startDate.toISOString().split("T")[0]} ~ ${endDate.toISOString().split("T")[0]}`
+    );
+
+    await markSyncing(dataType);
+
+    try {
+      const synced = await withReauth((client) =>
+        SYNC_FNS[dataType](client, startDate, endDate)
+      );
+
+      await updateSyncMetadata(dataType, endDate, synced);
+      console.log(`[${dataType}] 싱크 완료: ${synced}건`);
+      results.push({ dataType, synced });
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
+      await updateSyncMetadata(dataType, endDate, 0, message);
+      console.error(`[${dataType}] 싱크 실패:`, message);
+      results.push({ dataType, synced: 0, error: message });
+      // 하나 실패해도 나머지 진행
+    }
+  }
+
+  return results;
+}
+
+export type { DataType, SyncResult };

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import prisma from "@/lib/prisma";
 import { withReauth } from "./client";
-import { daysAgo, yesterday } from "./utils";
+import { daysAgo, formatDate, yesterday } from "./utils";
 import { syncActivities } from "./fetchers/activities";
 import { syncDailySummaries } from "./fetchers/daily-summary";
 import { syncSleep } from "./fetchers/sleep";
@@ -86,6 +86,23 @@ async function updateSyncMetadata(
   });
 }
 
+async function markError(
+  dataType: DataType,
+  errorMessage: string
+): Promise<void> {
+  await prisma.syncMetadata.upsert({
+    where: { dataType },
+    update: { status: "error", errorMessage },
+    create: {
+      dataType,
+      lastSyncAt: new Date(),
+      lastSyncDate: new Date(0),
+      status: "error",
+      errorMessage,
+    },
+  });
+}
+
 async function markSyncing(dataType: DataType): Promise<void> {
   await prisma.syncMetadata.upsert({
     where: { dataType },
@@ -114,13 +131,13 @@ export async function syncAll(
     const startDate = options?.startDate ?? (await getStartDate(dataType));
 
     if (startDate > endDate) {
-      console.log(`[${dataType}] 이미 최신 상태 (${startDate.toISOString().split("T")[0]}까지 싱크 완료)`);
+      console.log(`[${dataType}] 이미 최신 상태 (${formatDate(startDate)}까지 싱크 완료)`);
       results.push({ dataType, synced: 0 });
       continue;
     }
 
     console.log(
-      `[${dataType}] 싱크 시작: ${startDate.toISOString().split("T")[0]} ~ ${endDate.toISOString().split("T")[0]}`
+      `[${dataType}] 싱크 시작: ${formatDate(startDate)} ~ ${formatDate(endDate)}`
     );
 
     await markSyncing(dataType);
@@ -136,7 +153,8 @@ export async function syncAll(
     } catch (error) {
       const message =
         error instanceof Error ? error.message : String(error);
-      await updateSyncMetadata(dataType, endDate, 0, message);
+      // 실패 시 lastSyncDate를 업데이트하지 않음 → 다음 싱크에서 같은 범위 재시도
+      await markError(dataType, message);
       console.error(`[${dataType}] 싱크 실패:`, message);
       results.push({ dataType, synced: 0, error: message });
       // 하나 실패해도 나머지 진행

--- a/src/lib/garmin/utils.ts
+++ b/src/lib/garmin/utils.ts
@@ -1,0 +1,51 @@
+export function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function formatDate(date: Date): string {
+  return date.toISOString().split("T")[0];
+}
+
+export function dateRange(startDate: Date, endDate: Date): Date[] {
+  const dates: Date[] = [];
+  const current = new Date(startDate);
+  current.setHours(0, 0, 0, 0);
+
+  const end = new Date(endDate);
+  end.setHours(0, 0, 0, 0);
+
+  while (current <= end) {
+    dates.push(new Date(current));
+    current.setDate(current.getDate() + 1);
+  }
+
+  return dates;
+}
+
+export function startOfDay(date: Date): Date {
+  const d = new Date(date);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function yesterday(): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - 1);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+export function daysAgo(n: number): Date {
+  const d = new Date();
+  d.setDate(d.getDate() - n);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+const API_DELAY_MS = 2000;
+
+export async function withRateLimit<T>(fn: () => Promise<T>): Promise<T> {
+  const result = await fn();
+  await delay(API_DELAY_MS);
+  return result;
+}

--- a/src/lib/garmin/utils.ts
+++ b/src/lib/garmin/utils.ts
@@ -3,7 +3,10 @@ export function delay(ms: number): Promise<void> {
 }
 
 export function formatDate(date: Date): string {
-  return date.toISOString().split("T")[0];
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, "0");
+  const d = String(date.getDate()).padStart(2, "0");
+  return `${y}-${m}-${d}`;
 }
 
 export function dateRange(startDate: Date, endDate: Date): Date[] {
@@ -40,6 +43,31 @@ export function daysAgo(n: number): Date {
   d.setDate(d.getDate() - n);
   d.setHours(0, 0, 0, 0);
   return d;
+}
+
+/** 데이터 없음 에러인지 판단. 404/204 또는 "not found"/"empty" 메시지 */
+export function isNoDataError(error: unknown): boolean {
+  if (error instanceof Error) {
+    const msg = error.message.toLowerCase();
+    if (
+      msg.includes("not found") ||
+      msg.includes("empty") ||
+      msg.includes("no data") ||
+      msg.includes("invalid") ||
+      msg.includes("404")
+    ) {
+      return true;
+    }
+  }
+
+  const status =
+    error !== null &&
+    typeof error === "object" &&
+    "status" in error
+      ? (error as { status: number }).status
+      : undefined;
+
+  return status === 404 || status === 204;
 }
 
 const API_DELAY_MS = 2000;


### PR DESCRIPTION
## 변경 사항

Garmin Connect에서 데이터를 가져와 DB에 저장하는 싱크 엔진.

### 5개 fetcher
| fetcher | 데이터 | upsert 키 |
|---|---|---|
| activities | 운동 기록 (페이스, HR, 거리 등) | garminId |
| daily-summary | 걸음/칼로리/스트레스/바디배터리 | date |
| sleep | 수면 단계별 기록 + 점수 | date |
| heart-rate | 안정시 심박 + HRV | date |
| body-composition | 체중/체지방 | date |

### 싱크 오케스트레이터
- 데이터 타입별 독립 싱크 (하나 실패해도 나머지 진행)
- SyncMetadata 추적 (상태, 마지막 싱크 날짜, 건수)
- API 호출 간 2초 딜레이 (rate limit 방지)
- 초기 365일 히스토리 / 증분 싱크 자동 판단

### 싱크 스크립트
```bash
npx tsx scripts/sync-garmin.ts           # 초기 로드 또는 증분 싱크
npx tsx scripts/sync-garmin.ts --days=7  # 최근 7일만
```

Closes #8

## 체크리스트

- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공
- [x] 싱크 테스트 완료

## 스펙 문서

`docs/specs/4-garmin-sync-engine.md`