### PR TITLE
[Phase 1] 수동 싱크 API + 싱크 상태 관리 (#10)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -7,7 +7,7 @@
 - [x] #1 프로젝트 초기화 + PM2 배포 설정
 - [x] #2 DB 스키마 설계 + Prisma 마이그레이션
 - [x] #3 Garmin Connect 연동 + 인증
-- [ ] #4 Garmin 데이터 싱크 엔진 (365일 히스토리)
+- [x] #4 Garmin 데이터 싱크 엔진 (365일 히스토리)
 - [ ] #5 수동 싱크 API + 싱크 상태 관리
 
 ## Phase 2: Dashboard & Visualization (이슈 #6~#10)

--- a/docs/specs/5-sync-api.md
+++ b/docs/specs/5-sync-api.md
@@ -1,0 +1,61 @@
+# [Phase 1] 수동 싱크 API + 싱크 상태 관리
+
+## 목적
+
+웹에서 수동으로 Garmin 싱크를 트리거하고, 싱크 상태를 조회할 수 있는 API 구현.
+
+## 요구사항
+
+- [ ] `POST /api/sync` — 수동 싱크 트리거 (날짜 범위, 데이터 타입 선택 가능)
+- [ ] `GET /api/sync/status` — 데이터 타입별 싱크 상태 조회
+- [ ] 기본 동작: 최근 3일 싱크 (날짜 미지정 시)
+- [ ] 응답에 싱크 결과 요약 포함
+
+## 기술 설계
+
+### POST /api/sync
+
+```typescript
+// Request body (모두 optional)
+{
+  startDate?: string,  // "2026-04-01" (미지정 시 3일 전)
+  endDate?: string,    // "2026-04-07" (미지정 시 어제)
+  dataTypes?: string[] // ["activities", "sleep"] (미지정 시 전체)
+}
+
+// Response
+{
+  results: [
+    { dataType: "daily_stats", synced: 5 },
+    { dataType: "activities", synced: 2, error?: "..." }
+  ]
+}
+```
+
+### GET /api/sync/status
+
+```typescript
+// Response
+{
+  data: [
+    {
+      dataType: "daily_stats",
+      lastSyncAt: "2026-04-07T06:00:00Z",
+      lastSyncDate: "2026-04-06",
+      syncCount: 365,
+      status: "idle"
+    }
+  ]
+}
+```
+
+## 테스트 계획
+
+- [ ] `curl -X POST localhost:3000/api/sync` → 싱크 실행 + 결과 반환
+- [ ] `curl localhost:3000/api/sync/status` → 상태 조회
+- [ ] `npm run lint` + `npx tsc --noEmit` + `npm run build` 통과
+
+## 제외 사항
+
+- Cron 자동 싱크 (Phase 3)
+- 싱크 진행률 실시간 표시 (Phase 2+)

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -11,27 +11,63 @@ const VALID_DATA_TYPES: DataType[] = [
   "body_composition",
 ];
 
+/** "YYYY-MM-DD" 문자열을 로컬 midnight Date로 파싱. 무효하면 null. */
+function parseLocalDate(dateStr: string): Date | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(dateStr);
+  if (!match) return null;
+
+  const [, y, m, d] = match;
+  const date = new Date(Number(y), Number(m) - 1, Number(d));
+
+  // 파싱 결과가 입력과 일치하는지 검증 (2월 30일 등 방지)
+  if (
+    date.getFullYear() !== Number(y) ||
+    date.getMonth() !== Number(m) - 1 ||
+    date.getDate() !== Number(d)
+  ) {
+    return null;
+  }
+
+  return date;
+}
+
 export async function POST(request: Request) {
   try {
     const body = await request.json().catch(() => ({}));
 
-    const endDate = body.endDate
-      ? new Date(body.endDate)
-      : (() => {
-          const d = new Date();
-          d.setDate(d.getDate() - 1);
-          d.setHours(0, 0, 0, 0);
-          return d;
-        })();
+    let endDate: Date;
+    if (body.endDate) {
+      const parsed = parseLocalDate(body.endDate);
+      if (!parsed) {
+        return NextResponse.json(
+          { error: `유효하지 않은 날짜: ${body.endDate} (YYYY-MM-DD 형식)` },
+          { status: 400 }
+        );
+      }
+      endDate = parsed;
+    } else {
+      const d = new Date();
+      d.setDate(d.getDate() - 1);
+      d.setHours(0, 0, 0, 0);
+      endDate = d;
+    }
 
-    const startDate = body.startDate
-      ? new Date(body.startDate)
-      : (() => {
-          const d = new Date();
-          d.setDate(d.getDate() - DEFAULT_DAYS);
-          d.setHours(0, 0, 0, 0);
-          return d;
-        })();
+    let startDate: Date;
+    if (body.startDate) {
+      const parsed = parseLocalDate(body.startDate);
+      if (!parsed) {
+        return NextResponse.json(
+          { error: `유효하지 않은 날짜: ${body.startDate} (YYYY-MM-DD 형식)` },
+          { status: 400 }
+        );
+      }
+      startDate = parsed;
+    } else {
+      const d = new Date();
+      d.setDate(d.getDate() - DEFAULT_DAYS);
+      d.setHours(0, 0, 0, 0);
+      startDate = d;
+    }
 
     const dataTypes = body.dataTypes
       ? (body.dataTypes as string[]).filter((t): t is DataType =>

--- a/src/app/api/sync/route.ts
+++ b/src/app/api/sync/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { syncAll, type DataType } from "@/lib/garmin/sync";
+
+const DEFAULT_DAYS = 3;
+
+const VALID_DATA_TYPES: DataType[] = [
+  "daily_stats",
+  "activities",
+  "sleep",
+  "heart_rate",
+  "body_composition",
+];
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+
+    const endDate = body.endDate
+      ? new Date(body.endDate)
+      : (() => {
+          const d = new Date();
+          d.setDate(d.getDate() - 1);
+          d.setHours(0, 0, 0, 0);
+          return d;
+        })();
+
+    const startDate = body.startDate
+      ? new Date(body.startDate)
+      : (() => {
+          const d = new Date();
+          d.setDate(d.getDate() - DEFAULT_DAYS);
+          d.setHours(0, 0, 0, 0);
+          return d;
+        })();
+
+    const dataTypes = body.dataTypes
+      ? (body.dataTypes as string[]).filter((t): t is DataType =>
+          VALID_DATA_TYPES.includes(t as DataType)
+        )
+      : undefined;
+
+    const results = await syncAll({ startDate, endDate, dataTypes });
+
+    return NextResponse.json({ results });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/sync/status/route.ts
+++ b/src/app/api/sync/status/route.ts
@@ -1,0 +1,15 @@
+import { NextResponse } from "next/server";
+import prisma from "@/lib/prisma";
+
+export async function GET() {
+  try {
+    const statuses = await prisma.syncMetadata.findMany({
+      orderBy: { dataType: "asc" },
+    });
+
+    return NextResponse.json({ data: statuses });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}


### PR DESCRIPTION
## 변경 사항

| 엔드포인트 | 메서드 | 설명 |
|---|---|---|
| `/api/sync` | POST | 수동 싱크 트리거 |
| `/api/sync/status` | GET | 데이터 타입별 싱크 상태 조회 |

### POST /api/sync
- `startDate`, `endDate`, `dataTypes` 옵션 (모두 optional)
- 기본: 최근 3일, 전체 데이터 타입
- 응답: `{ results: [{ dataType, synced, error? }] }`

### GET /api/sync/status
- SyncMetadata 전체 조회
- 응답: `{ data: [{ dataType, lastSyncAt, lastSyncDate, syncCount, status }] }`

Closes #10

## 체크리스트

- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 성공

## 스펙 문서

`docs/specs/5-sync-api.md`