### PR TITLE
[M2] DB 스키마 확장 + 싱크 fetcher 보강 (#35)

### DIFF
--- a/prisma/migrations/20260407084504_m2_expand_schema/migration.sql
+++ b/prisma/migrations/20260407084504_m2_expand_schema/migration.sql
@@ -1,0 +1,30 @@
+-- AlterTable
+ALTER TABLE "Activity" ADD COLUMN     "aerobicTE" DOUBLE PRECISION,
+ADD COLUMN     "anaerobicTE" DOUBLE PRECISION,
+ADD COLUMN     "avgCadence" INTEGER,
+ADD COLUMN     "avgGroundContactTime" DOUBLE PRECISION,
+ADD COLUMN     "avgRespirationRate" DOUBLE PRECISION,
+ADD COLUMN     "avgStrideLength" DOUBLE PRECISION,
+ADD COLUMN     "avgVerticalOscillation" DOUBLE PRECISION,
+ADD COLUMN     "lapCount" INTEGER,
+ADD COLUMN     "splitSummaries" JSONB;
+
+-- AlterTable
+ALTER TABLE "DailySummary" ADD COLUMN     "avgRespiration" DOUBLE PRECISION,
+ADD COLUMN     "avgSpo2" DOUBLE PRECISION,
+ADD COLUMN     "bodyBatteryCharged" INTEGER,
+ADD COLUMN     "bodyBatteryDrained" INTEGER,
+ADD COLUMN     "lowestSpo2" DOUBLE PRECISION,
+ADD COLUMN     "stressHighDuration" INTEGER,
+ADD COLUMN     "stressLowDuration" INTEGER,
+ADD COLUMN     "stressMediumDuration" INTEGER;
+
+-- AlterTable
+ALTER TABLE "SleepRecord" ADD COLUMN     "avgRespiration" DOUBLE PRECISION,
+ADD COLUMN     "avgSleepStress" DOUBLE PRECISION,
+ADD COLUMN     "bodyBatteryChange" INTEGER,
+ADD COLUMN     "highestRespiration" DOUBLE PRECISION,
+ADD COLUMN     "hrvOvernight" DOUBLE PRECISION,
+ADD COLUMN     "lowestRespiration" DOUBLE PRECISION,
+ADD COLUMN     "restingHR" INTEGER,
+ADD COLUMN     "sleepScoreDetails" JSONB;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,11 +21,11 @@ model UserProfile {
 
 model SyncMetadata {
   id            String   @id @default(cuid())
-  dataType      String   @unique     // "activities", "sleep", "daily_stats", "heart_rate", "body_composition"
+  dataType      String   @unique
   lastSyncAt    DateTime
-  lastSyncDate  DateTime             // 마지막으로 싱크한 날짜
+  lastSyncDate  DateTime
   syncCount     Int      @default(0)
-  status        String   @default("idle") // "idle", "syncing", "error"
+  status        String   @default("idle")
   errorMessage  String?
   updatedAt     DateTime @updatedAt
 }
@@ -33,7 +33,7 @@ model SyncMetadata {
 model Activity {
   id              String   @id @default(cuid())
   garminId        BigInt   @unique
-  activityType    String              // "running", "cycling", "strength", "walking" 등
+  activityType    String
   name            String
   startTime       DateTime
   duration        Int                 // seconds
@@ -41,12 +41,22 @@ model Activity {
   calories        Int?
   avgHR           Int?                // bpm
   maxHR           Int?                // bpm
-  avgPace         Float?              // sec/km (러닝)
+  avgPace         Float?              // sec/km
   avgSpeed        Float?              // km/h
   elevationGain   Float?              // meters
   trainingEffect  Float?              // 1.0-5.0
   vo2maxEstimate  Float?
-  rawData         Json?               // 전체 Garmin 응답 보존
+  // M2: 러닝 다이나믹스
+  avgCadence      Int?                // spm (steps per minute)
+  avgStrideLength Float?              // meters
+  avgVerticalOscillation Float?       // cm
+  avgGroundContactTime   Float?       // ms
+  aerobicTE       Float?              // 유산소 트레이닝 이펙트
+  anaerobicTE     Float?              // 무산소 트레이닝 이펙트
+  avgRespirationRate Float?           // breaths/min
+  lapCount        Int?
+  splitSummaries  Json?               // km별 스플릿 데이터
+  rawData         Json?
   createdAt       DateTime @default(now())
 
   @@index([activityType, startTime])
@@ -55,33 +65,51 @@ model Activity {
 
 model DailySummary {
   id              String   @id @default(cuid())
-  date            DateTime @unique     // 날짜 (midnight)
+  date            DateTime @unique
   steps           Int?
-  totalCalories   Int?                 // 총 kcal
+  totalCalories   Int?
   activeCalories  Int?
-  restingHR       Int?                 // bpm
+  restingHR       Int?
   avgStress       Int?                 // 1-100
   bodyBattery     Int?                 // 5-100 (하루 끝)
   bodyBatteryHigh Int?
   bodyBatteryLow  Int?
-  intensityMin    Int?                 // 활동 강도 분
+  intensityMin    Int?
   floorsClimbed   Int?
+  // M2: 추가 지표
+  avgSpo2         Float?               // %
+  lowestSpo2      Float?               // %
+  avgRespiration  Float?               // breaths/min
+  stressHighDuration  Int?             // minutes
+  stressMediumDuration Int?            // minutes
+  stressLowDuration   Int?             // minutes
+  bodyBatteryCharged  Int?             // 충전량
+  bodyBatteryDrained  Int?             // 소모량
   rawData         Json?
   createdAt       DateTime @default(now())
 }
 
 model SleepRecord {
   id            String   @id @default(cuid())
-  date          DateTime @unique       // 수면 날짜 (밤 기준)
+  date          DateTime @unique
   sleepStart    DateTime
   sleepEnd      DateTime
   totalSleep    Int                    // minutes
-  deepSleep     Int?                   // minutes
-  lightSleep    Int?                   // minutes
-  remSleep      Int?                   // minutes
-  awakeDuration Int?                   // minutes
+  deepSleep     Int?
+  lightSleep    Int?
+  remSleep      Int?
+  awakeDuration Int?
   sleepScore    Int?                   // 0-100
   avgSpO2       Float?
+  // M2: 추가 지표
+  avgRespiration    Float?             // breaths/min
+  lowestRespiration Float?
+  highestRespiration Float?
+  avgSleepStress    Float?             // 수면 중 스트레스
+  bodyBatteryChange Int?               // 수면 중 배터리 변화량
+  restingHR         Int?               // 수면 중 안정시 심박
+  hrvOvernight      Float?             // ms, 야간 HRV
+  sleepScoreDetails Json?              // 점수 세부 (duration/stress/rem/deep/light/restlessness)
   rawData       Json?
   createdAt     DateTime @default(now())
 }
@@ -89,11 +117,11 @@ model SleepRecord {
 model HeartRateRecord {
   id          String   @id @default(cuid())
   date        DateTime @unique
-  restingHR   Int?                     // bpm
+  restingHR   Int?
   avgHR       Int?
   maxHR       Int?
   minHR       Int?
-  hrvStatus   Float?                   // ms (HRV 값)
+  hrvStatus   Float?                   // ms
   hrvBaseline Float?                   // ms
   rawData     Json?
   createdAt   DateTime @default(now())
@@ -112,9 +140,9 @@ model BodyComposition {
 
 model AIAdvice {
   id        String   @id @default(cuid())
-  category  String                     // "exercise", "sleep", "heart", "diet", "lifestyle", "weekly_report"
+  category  String
   prompt    String
-  response  String                     // markdown
+  response  String
   createdAt DateTime @default(now())
 
   @@index([category, createdAt])
@@ -123,9 +151,9 @@ model AIAdvice {
 model FoodLog {
   id            String   @id @default(cuid())
   date          DateTime
-  description   String                 // 자유 텍스트, AI가 칼로리 추정
+  description   String
   estimatedKcal Int?
-  mealType      String?                // "breakfast", "lunch", "dinner", "snack"
+  mealType      String?
   createdAt     DateTime @default(now())
 
   @@index([date])

--- a/src/lib/garmin/fetchers/activities.ts
+++ b/src/lib/garmin/fetchers/activities.ts
@@ -1,5 +1,5 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
-import type { Prisma } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { withRateLimit } from "../utils";
 
@@ -65,7 +65,9 @@ export async function syncActivities(
         anaerobicTE: toFloat(summaryDTO?.anaerobicTrainingEffect),
         avgRespirationRate: toFloat(raw.avgRespirationRate),
         lapCount: toInt(raw.lapCount),
-        splitSummaries: (a.splitSummaries ?? null) as Prisma.InputJsonValue,
+        splitSummaries: a.splitSummaries
+          ? (a.splitSummaries as Prisma.InputJsonValue)
+          : Prisma.DbNull,
         rawData: raw as Prisma.InputJsonValue,
       };
 

--- a/src/lib/garmin/fetchers/activities.ts
+++ b/src/lib/garmin/fetchers/activities.ts
@@ -36,7 +36,6 @@ export async function syncActivities(
         continue;
       }
 
-      // IActivity 타입에 없는 필드는 any 캐스팅
       const raw = a as unknown as Record<string, unknown>;
       const summaryDTO = raw.summaryDTO as Record<string, unknown> | undefined;
 
@@ -57,6 +56,16 @@ export async function syncActivities(
         elevationGain: a.elevationGain ?? null,
         trainingEffect: (summaryDTO?.trainingEffect as number) ?? null,
         vo2maxEstimate: (raw.vO2MaxValue as number) ?? null,
+        // M2: 러닝 다이나믹스
+        avgCadence: toInt(summaryDTO?.averageRunCadence),
+        avgStrideLength: toFloat(summaryDTO?.strideLength),
+        avgVerticalOscillation: toFloat(summaryDTO?.verticalOscillation),
+        avgGroundContactTime: toFloat(summaryDTO?.groundContactTime),
+        aerobicTE: toFloat(summaryDTO?.trainingEffect),
+        anaerobicTE: toFloat(summaryDTO?.anaerobicTrainingEffect),
+        avgRespirationRate: toFloat(raw.avgRespirationRate),
+        lapCount: toInt(raw.lapCount),
+        splitSummaries: (a.splitSummaries ?? null) as Prisma.InputJsonValue,
         rawData: raw as Prisma.InputJsonValue,
       };
 
@@ -73,4 +82,16 @@ export async function syncActivities(
   }
 
   return synced;
+}
+
+function toInt(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : Math.round(n);
+}
+
+function toFloat(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : n;
 }

--- a/src/lib/garmin/fetchers/daily-summary.ts
+++ b/src/lib/garmin/fetchers/daily-summary.ts
@@ -44,6 +44,15 @@ export async function syncDailySummaries(
         bodyBatteryLow: toInt(summary.bodyBatteryLowestValue),
         intensityMin,
         floorsClimbed: toInt(summary.floorsAscended),
+        // M2: 추가 지표
+        avgSpo2: toFloat(summary.averageSpo2),
+        lowestSpo2: toFloat(summary.lowestSpo2),
+        avgRespiration: toFloat(summary.avgWakingRespirationValue),
+        stressHighDuration: toMinutes(summary.highStressDuration),
+        stressMediumDuration: toMinutes(summary.mediumStressDuration),
+        stressLowDuration: toMinutes(summary.lowStressDuration),
+        bodyBatteryCharged: toInt(summary.bodyBatteryChargedValue),
+        bodyBatteryDrained: toInt(summary.bodyBatteryDrainedValue),
         rawData: summary as Prisma.InputJsonValue,
       };
 
@@ -55,7 +64,6 @@ export async function syncDailySummaries(
 
       synced++;
     } catch (error) {
-      // 404/데이터 없음은 건너뜀, 그 외(401/403/네트워크)는 상위로 전파
       const msg = error instanceof Error ? error.message : String(error);
       if (msg.includes("404") || msg.includes("not found")) continue;
       throw error;
@@ -69,4 +77,17 @@ function toInt(val: unknown): number | null {
   if (val === null || val === undefined) return null;
   const n = Number(val);
   return isNaN(n) ? null : Math.round(n);
+}
+
+function toFloat(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : n;
+}
+
+/** Garmin은 스트레스 시간을 초 단위로 반환 → 분으로 변환 */
+function toMinutes(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : Math.round(n / 60);
 }

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -1,5 +1,5 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
-import type { Prisma } from "@/generated/prisma/client";
+import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { dateRange, isNoDataError, withRateLimit } from "../utils";
 
@@ -80,7 +80,9 @@ export async function syncSleep(
         bodyBatteryChange: toInt(sleepData.bodyBatteryChange),
         restingHR: toInt(sleepData.restingHeartRate),
         hrvOvernight: toFloat(sleepData.avgOvernightHrv),
-        sleepScoreDetails: sleepScoreDetails as Prisma.InputJsonValue,
+        sleepScoreDetails: sleepScoreDetails
+          ? (sleepScoreDetails as Prisma.InputJsonValue)
+          : Prisma.DbNull,
         rawData: sleepData as unknown as Prisma.InputJsonValue,
       };
 

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -21,13 +21,35 @@ export async function syncSleep(
 
       if (!dto.sleepStartTimestampGMT || !dto.sleepEndTimestampGMT) continue;
 
-      // Garmin의 calendarDate 사용 (기상일 기준, Garmin UI와 일치)
       const calendarDate = dto.calendarDate;
       if (!calendarDate) continue;
 
       const [year, month, day] = calendarDate.split("-").map(Number);
       const dayDate = new Date(year, month - 1, day);
       dayDate.setHours(0, 0, 0, 0);
+
+      // 수면 점수 세부
+      const sleepScoreDetails = dto.sleepScores
+        ? {
+            overall: dto.sleepScores.overall?.value ?? null,
+            duration: dto.sleepScores.totalDuration?.qualifierKey ?? null,
+            stress: dto.sleepScores.stress?.qualifierKey ?? null,
+            awakeCount: dto.sleepScores.awakeCount?.qualifierKey ?? null,
+            remPercentage: {
+              value: dto.sleepScores.remPercentage?.value ?? null,
+              qualifier: dto.sleepScores.remPercentage?.qualifierKey ?? null,
+            },
+            deepPercentage: {
+              value: dto.sleepScores.deepPercentage?.value ?? null,
+              qualifier: dto.sleepScores.deepPercentage?.qualifierKey ?? null,
+            },
+            lightPercentage: {
+              value: dto.sleepScores.lightPercentage?.value ?? null,
+              qualifier: dto.sleepScores.lightPercentage?.qualifierKey ?? null,
+            },
+            restlessness: dto.sleepScores.restlessness?.qualifierKey ?? null,
+          }
+        : null;
 
       const data = {
         sleepStart: new Date(dto.sleepStartTimestampGMT),
@@ -46,7 +68,19 @@ export async function syncSleep(
           ? Math.round(dto.awakeSleepSeconds / 60)
           : null,
         sleepScore: dto.sleepScores?.overall?.value ?? null,
-        avgSpO2: null as number | null,
+        // M2: 추가 지표
+        avgSpO2: toFloat(
+          (sleepData as unknown as Record<string, unknown>).averageSpo2 ??
+          (dto as unknown as Record<string, unknown>).averageSpo2
+        ),
+        avgRespiration: toFloat(dto.averageRespirationValue),
+        lowestRespiration: toFloat(dto.lowestRespirationValue),
+        highestRespiration: toFloat(dto.highestRespirationValue),
+        avgSleepStress: toFloat(dto.avgSleepStress),
+        bodyBatteryChange: toInt(sleepData.bodyBatteryChange),
+        restingHR: toInt(sleepData.restingHeartRate),
+        hrvOvernight: toFloat(sleepData.avgOvernightHrv),
+        sleepScoreDetails: sleepScoreDetails as Prisma.InputJsonValue,
         rawData: sleepData as unknown as Prisma.InputJsonValue,
       };
 
@@ -64,4 +98,16 @@ export async function syncSleep(
   }
 
   return synced;
+}
+
+function toInt(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : Math.round(n);
+}
+
+function toFloat(val: unknown): number | null {
+  if (val === null || val === undefined) return null;
+  const n = Number(val);
+  return isNaN(n) ? null : n;
 }


### PR DESCRIPTION
## 변경 사항

마일스톤 2를 위한 DB 스키마 확장 및 Garmin 싱크 fetcher 보강.

### Activity 모델 (9개 필드 추가)
| 필드 | 설명 |
|---|---|
| avgCadence | 러닝 케이던스 (spm) |
| avgStrideLength | 보폭 (m) |
| avgVerticalOscillation | 수직 진동 (cm) |
| avgGroundContactTime | 지면접촉시간 (ms) |
| aerobicTE / anaerobicTE | 유산소/무산소 트레이닝 이펙트 |
| avgRespirationRate | 평균 호흡수 |
| lapCount | 랩 수 |
| splitSummaries | km별 스플릿 데이터 (JSON) |

### SleepRecord 모델 (8개 필드 추가)
| 필드 | 설명 |
|---|---|
| avgRespiration / lowest / highest | 호흡수 |
| avgSleepStress | 수면 중 스트레스 |
| bodyBatteryChange | 수면 중 배터리 변화량 |
| restingHR | 수면 중 안정시 심박 |
| hrvOvernight | 야간 HRV |
| sleepScoreDetails | 점수 세부 (JSON) |

### DailySummary 모델 (8개 필드 추가)
| 필드 | 설명 |
|---|---|
| avgSpo2 / lowestSpo2 | SpO2 |
| avgRespiration | 호흡수 |
| stressHigh/Medium/LowDuration | 스트레스 세부 (분) |
| bodyBatteryCharged / Drained | 배터리 충전/소모 |

Closes #35

## 재싱크 필요
머지 후 전체 데이터 재싱크로 새 필드에 데이터 적재:
```bash
curl -X POST .../api/sync -d '{"startDate": "2025-04-01"}'
```