### PR TITLE
[M4-1] 최대심박수/LTHR 저장 및 활용 (#53)

### DIFF
--- a/prisma/migrations/20260415000341_add_user_zones/migration.sql
+++ b/prisma/migrations/20260415000341_add_user_zones/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "UserProfile" ADD COLUMN     "lthr" INTEGER,
+ADD COLUMN     "lthrPace" DOUBLE PRECISION,
+ADD COLUMN     "maxHR" INTEGER,
+ADD COLUMN     "targetCalories" INTEGER;

--- a/prisma/migrations/20260415092700_add_user_profile_singleton/migration.sql
+++ b/prisma/migrations/20260415092700_add_user_profile_singleton/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable
+ALTER TABLE "UserProfile" ADD COLUMN "singleton" BOOLEAN NOT NULL DEFAULT true;
+
+-- CreateIndex
+CREATE UNIQUE INDEX "UserProfile_singleton_key" ON "UserProfile"("singleton");

--- a/prisma/migrations/20260415092700_add_user_profile_singleton/migration.sql
+++ b/prisma/migrations/20260415092700_add_user_profile_singleton/migration.sql
@@ -1,5 +1,14 @@
--- AlterTable
+-- AlterTable: 싱글톤 sentinel 컬럼 추가 (모든 기존 row는 default true)
 ALTER TABLE "UserProfile" ADD COLUMN "singleton" BOOLEAN NOT NULL DEFAULT true;
+
+-- 싱글톤 보장: 중복 row가 존재할 경우 가장 오래된 것만 남기고 삭제.
+-- unique 인덱스 생성 전에 실행해야 함 (dedupe-aware).
+DELETE FROM "UserProfile"
+WHERE id NOT IN (
+  SELECT id FROM "UserProfile"
+  ORDER BY "createdAt" ASC, id ASC
+  LIMIT 1
+);
 
 -- CreateIndex
 CREATE UNIQUE INDEX "UserProfile_singleton_key" ON "UserProfile"("singleton");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,14 +9,18 @@ datasource db {
 }
 
 model UserProfile {
-  id            String    @id @default(cuid())
-  name          String
-  birthDate     DateTime?
-  height        Float?              // cm
-  targetWeight  Float?              // kg
-  restingHRBase Int?                // 기준 안정시 심박수
-  createdAt     DateTime  @default(now())
-  updatedAt     DateTime  @updatedAt
+  id             String    @id @default(cuid())
+  name           String
+  birthDate      DateTime?
+  height         Float?              // cm
+  targetWeight   Float?              // kg
+  restingHRBase  Int?                // 기준 안정시 심박수
+  maxHR          Int?                // 실측 최대 심박 (bpm)
+  lthr           Int?                // 젖산역치 심박 (bpm)
+  lthrPace       Float?              // LTHR 페이스 (sec/km)
+  targetCalories Int?                // 일일 칼로리 목표 (kcal)
+  createdAt      DateTime  @default(now())
+  updatedAt      DateTime  @updatedAt
 }
 
 model SyncMetadata {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,6 +10,8 @@ datasource db {
 
 model UserProfile {
   id             String    @id @default(cuid())
+  // 싱글톤 보장용 sentinel. 항상 true로 설정되며 unique 제약으로 중복 row 생성을 차단.
+  singleton      Boolean   @default(true) @unique
   name           String
   birthDate      DateTime?
   height         Float?              // cm

--- a/src/app/activities/activities-client.tsx
+++ b/src/app/activities/activities-client.tsx
@@ -52,6 +52,7 @@ interface ActivitiesClientProps {
   activities: Activity[];
   monthSummary: MonthSummary;
   estimatedMaxHR: number;
+  userLTHR: number | null;
   runningRecords: RunningRecord[];
   weeklyVolumes: WeekVolume[];
   overtrainingRisk: OvertrainingRisk;
@@ -68,6 +69,7 @@ export default function ActivitiesClient({
   activities,
   monthSummary,
   estimatedMaxHR,
+  userLTHR,
   runningRecords,
   weeklyVolumes,
   overtrainingRisk,
@@ -178,6 +180,7 @@ export default function ActivitiesClient({
           <RunningAnalysis
             records={runningRecords}
             estimatedMaxHR={estimatedMaxHR}
+            userLTHR={userLTHR}
           />
         </div>
       )}

--- a/src/app/activities/page.tsx
+++ b/src/app/activities/page.tsx
@@ -1,5 +1,6 @@
 import prisma from "@/lib/prisma";
 import { formatDateLocal } from "@/lib/format";
+import { resolveMaxHR } from "@/lib/fitness/zones";
 import ActivitiesClient from "./activities-client";
 
 export const dynamic = "force-dynamic";
@@ -27,11 +28,10 @@ export default async function ActivitiesPage() {
   const monthStart = new Date(Date.UTC(kstNow.getFullYear(), kstNow.getMonth(), 1) - 9 * 60 * 60 * 1000);
   const eightWeeksAgo = weeksAgo(8);
 
-  // 최대 심박수 추정 (UserProfile 나이 기반 또는 실측 maxHR)
+  // 최대 심박수/LTHR: UserProfile 실측값 → 나이 기반 fallback
   const userProfile = await prisma.userProfile.findFirst();
-  const estimatedMaxHR = userProfile?.birthDate
-    ? 220 - Math.floor((Date.now() - userProfile.birthDate.getTime()) / (365.25 * 24 * 60 * 60 * 1000))
-    : 190;
+  const estimatedMaxHR = resolveMaxHR(userProfile ?? {});
+  const userLTHR = userProfile?.lthr ?? null;
 
   const activities = await prisma.activity.findMany({
     orderBy: { startTime: "desc" },
@@ -169,6 +169,7 @@ export default async function ActivitiesPage() {
       }))}
       monthSummary={monthSummary}
       estimatedMaxHR={estimatedMaxHR}
+      userLTHR={userLTHR}
       runningRecords={runningRecords.map((r) => ({
         date: formatDateLocal(r.startTime),
         avgPace: r.avgPace,

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -33,14 +33,21 @@ const PATCH_SCHEMA = z.object({
 
 const DEFAULT_NAME = "사용자";
 
+/**
+ * 싱글톤 UserProfile 조회 또는 생성.
+ * `singleton` unique 제약으로 동시 요청 시에도 중복 row 생성 불가.
+ */
+async function getOrCreateProfile() {
+  return prisma.userProfile.upsert({
+    where: { singleton: true },
+    update: {},
+    create: { singleton: true, name: DEFAULT_NAME },
+  });
+}
+
 export async function GET() {
   try {
-    let profile = await prisma.userProfile.findFirst();
-    if (!profile) {
-      profile = await prisma.userProfile.create({
-        data: { name: DEFAULT_NAME },
-      });
-    }
+    const profile = await getOrCreateProfile();
     return NextResponse.json({ profile });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -61,20 +68,21 @@ export async function PATCH(request: Request) {
 
     const data = parsed.data;
 
-    const existing = await prisma.userProfile.findFirst();
+    // 싱글톤 보장: 없으면 생성, 있으면 그대로 (update/create는 아래에서 결정)
+    const existing = await getOrCreateProfile();
 
     // 업데이트 후 예상 상태로 LTHR ≤ maxHR 검증.
     // maxHR 미설정 시 resolveMaxHR fallback(220-age 또는 190)과도 비교.
     const nextMaxHR =
-      data.maxHR !== undefined ? data.maxHR : (existing?.maxHR ?? null);
+      data.maxHR !== undefined ? data.maxHR : existing.maxHR;
     const nextLthr =
-      data.lthr !== undefined ? data.lthr : (existing?.lthr ?? null);
+      data.lthr !== undefined ? data.lthr : existing.lthr;
     const nextBirthDate =
       data.birthDate !== undefined
         ? data.birthDate
           ? new Date(data.birthDate)
           : null
-        : (existing?.birthDate ?? null);
+        : existing.birthDate;
     if (nextLthr !== null) {
       const compareMaxHR =
         nextMaxHR ??
@@ -108,17 +116,10 @@ export async function PATCH(request: Request) {
     if (data.targetCalories !== undefined)
       updatePayload.targetCalories = data.targetCalories;
 
-    const profile = existing
-      ? await prisma.userProfile.update({
-          where: { id: existing.id },
-          data: updatePayload,
-        })
-      : await prisma.userProfile.create({
-          data: {
-            name: data.name ?? DEFAULT_NAME,
-            ...updatePayload,
-          },
-        });
+    const profile = await prisma.userProfile.update({
+      where: { id: existing.id },
+      data: updatePayload,
+    });
 
     return NextResponse.json({ profile });
   } catch (error) {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,0 +1,103 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import prisma from "@/lib/prisma";
+
+const PATCH_SCHEMA = z.object({
+  name: z.string().trim().min(1).max(100).optional(),
+  birthDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식")
+    .nullable()
+    .optional(),
+  height: z.number().positive().max(300).nullable().optional(),
+  targetWeight: z.number().positive().max(500).nullable().optional(),
+  restingHRBase: z.number().int().min(20).max(150).nullable().optional(),
+  maxHR: z.number().int().min(100).max(230).nullable().optional(),
+  lthr: z.number().int().min(60).max(220).nullable().optional(),
+  lthrPace: z.number().positive().max(1200).nullable().optional(), // sec/km
+  targetCalories: z.number().int().min(500).max(8000).nullable().optional(),
+});
+
+const DEFAULT_NAME = "사용자";
+
+export async function GET() {
+  try {
+    let profile = await prisma.userProfile.findFirst();
+    if (!profile) {
+      profile = await prisma.userProfile.create({
+        data: { name: DEFAULT_NAME },
+      });
+    }
+    return NextResponse.json({ profile });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}
+
+export async function PATCH(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = PATCH_SCHEMA.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "유효하지 않은 입력", issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const data = parsed.data;
+
+    const existing = await prisma.userProfile.findFirst();
+
+    // lthr은 maxHR을 초과할 수 없음 (현재 값 또는 업데이트 후 값 기준)
+    const effectiveMaxHR =
+      data.maxHR !== undefined ? data.maxHR : (existing?.maxHR ?? null);
+    const effectiveLthr =
+      data.lthr !== undefined ? data.lthr : (existing?.lthr ?? null);
+    if (
+      effectiveMaxHR !== null &&
+      effectiveLthr !== null &&
+      effectiveLthr > effectiveMaxHR
+    ) {
+      return NextResponse.json(
+        { error: "LTHR은 최대심박수보다 작아야 합니다" },
+        { status: 400 }
+      );
+    }
+
+    const updatePayload: Record<string, unknown> = {};
+    if (data.name !== undefined) updatePayload.name = data.name;
+    if (data.birthDate !== undefined)
+      updatePayload.birthDate = data.birthDate
+        ? new Date(data.birthDate)
+        : null;
+    if (data.height !== undefined) updatePayload.height = data.height;
+    if (data.targetWeight !== undefined)
+      updatePayload.targetWeight = data.targetWeight;
+    if (data.restingHRBase !== undefined)
+      updatePayload.restingHRBase = data.restingHRBase;
+    if (data.maxHR !== undefined) updatePayload.maxHR = data.maxHR;
+    if (data.lthr !== undefined) updatePayload.lthr = data.lthr;
+    if (data.lthrPace !== undefined) updatePayload.lthrPace = data.lthrPace;
+    if (data.targetCalories !== undefined)
+      updatePayload.targetCalories = data.targetCalories;
+
+    const profile = existing
+      ? await prisma.userProfile.update({
+          where: { id: existing.id },
+          data: updatePayload,
+        })
+      : await prisma.userProfile.create({
+          data: {
+            name: data.name ?? DEFAULT_NAME,
+            ...updatePayload,
+          },
+        });
+
+    return NextResponse.json({ profile });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -1,21 +1,34 @@
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import prisma from "@/lib/prisma";
+import { resolveMaxHR } from "@/lib/fitness/zones";
+
+/** "YYYY-MM-DD" 형식이면서 실제 달력상 유효한 날짜인지 검증 */
+const birthDateSchema = z
+  .string()
+  .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식")
+  .refine((s) => {
+    const [y, m, d] = s.split("-").map(Number);
+    const date = new Date(Date.UTC(y, m - 1, d));
+    return (
+      date.getUTCFullYear() === y &&
+      date.getUTCMonth() === m - 1 &&
+      date.getUTCDate() === d
+    );
+  }, "유효하지 않은 날짜")
+  .nullable()
+  .optional();
 
 const PATCH_SCHEMA = z.object({
   name: z.string().trim().min(1).max(100).optional(),
-  birthDate: z
-    .string()
-    .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식")
-    .nullable()
-    .optional(),
+  birthDate: birthDateSchema,
   height: z.number().positive().max(300).nullable().optional(),
   targetWeight: z.number().positive().max(500).nullable().optional(),
   restingHRBase: z.number().int().min(20).max(150).nullable().optional(),
-  maxHR: z.number().int().min(100).max(230).nullable().optional(),
-  lthr: z.number().int().min(60).max(220).nullable().optional(),
+  maxHR: z.number().int().min(100).max(220).nullable().optional(),
+  lthr: z.number().int().min(80).max(220).nullable().optional(),
   lthrPace: z.number().positive().max(1200).nullable().optional(), // sec/km
-  targetCalories: z.number().int().min(500).max(8000).nullable().optional(),
+  targetCalories: z.number().int().min(500).max(5000).nullable().optional(),
 });
 
 const DEFAULT_NAME = "사용자";
@@ -50,20 +63,32 @@ export async function PATCH(request: Request) {
 
     const existing = await prisma.userProfile.findFirst();
 
-    // lthr은 maxHR을 초과할 수 없음 (현재 값 또는 업데이트 후 값 기준)
-    const effectiveMaxHR =
+    // 업데이트 후 예상 상태로 LTHR ≤ maxHR 검증.
+    // maxHR 미설정 시 resolveMaxHR fallback(220-age 또는 190)과도 비교.
+    const nextMaxHR =
       data.maxHR !== undefined ? data.maxHR : (existing?.maxHR ?? null);
-    const effectiveLthr =
+    const nextLthr =
       data.lthr !== undefined ? data.lthr : (existing?.lthr ?? null);
-    if (
-      effectiveMaxHR !== null &&
-      effectiveLthr !== null &&
-      effectiveLthr > effectiveMaxHR
-    ) {
-      return NextResponse.json(
-        { error: "LTHR은 최대심박수보다 작아야 합니다" },
-        { status: 400 }
-      );
+    const nextBirthDate =
+      data.birthDate !== undefined
+        ? data.birthDate
+          ? new Date(data.birthDate)
+          : null
+        : (existing?.birthDate ?? null);
+    if (nextLthr !== null) {
+      const compareMaxHR =
+        nextMaxHR ??
+        resolveMaxHR({ maxHR: null, birthDate: nextBirthDate ?? undefined });
+      if (nextLthr > compareMaxHR) {
+        return NextResponse.json(
+          {
+            error: `LTHR(${nextLthr})은 최대심박수(${compareMaxHR}${
+              nextMaxHR === null ? " — 추정값" : ""
+            })보다 작아야 합니다`,
+          },
+          { status: 400 }
+        );
+      }
     }
 
     const updatePayload: Record<string, unknown> = {};

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1,0 +1,25 @@
+import prisma from "@/lib/prisma";
+import ProfileClient from "./profile-client";
+
+export const dynamic = "force-dynamic";
+
+export default async function ProfilePage() {
+  const profile = await prisma.userProfile.findFirst();
+  return (
+    <ProfileClient
+      initial={{
+        name: profile?.name ?? "사용자",
+        birthDate: profile?.birthDate
+          ? profile.birthDate.toISOString().slice(0, 10)
+          : "",
+        height: profile?.height ?? null,
+        targetWeight: profile?.targetWeight ?? null,
+        restingHRBase: profile?.restingHRBase ?? null,
+        maxHR: profile?.maxHR ?? null,
+        lthr: profile?.lthr ?? null,
+        lthrPace: profile?.lthrPace ?? null,
+        targetCalories: profile?.targetCalories ?? null,
+      }}
+    />
+  );
+}

--- a/src/app/settings/profile/profile-client.tsx
+++ b/src/app/settings/profile/profile-client.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import { useState } from "react";
+
+interface ProfileValues {
+  name: string;
+  birthDate: string; // "YYYY-MM-DD" or ""
+  height: number | null;
+  targetWeight: number | null;
+  restingHRBase: number | null;
+  maxHR: number | null;
+  lthr: number | null;
+  lthrPace: number | null; // sec/km
+  targetCalories: number | null;
+}
+
+interface ProfileClientProps {
+  initial: ProfileValues;
+}
+
+/** "M:SS" → sec */
+function parsePace(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+  const match = /^(\d+):(\d{1,2})$/.exec(trimmed);
+  if (!match) return null;
+  const min = Number(match[1]);
+  const sec = Number(match[2]);
+  if (sec >= 60) return null;
+  return min * 60 + sec;
+}
+
+/** sec → "M:SS" */
+function formatPace(sec: number | null): string {
+  if (sec === null || !Number.isFinite(sec) || sec <= 0) return "";
+  const min = Math.floor(sec / 60);
+  const s = Math.round(sec - min * 60);
+  return `${min}:${String(s).padStart(2, "0")}`;
+}
+
+function toNumOrNull(v: string): number | null {
+  const trimmed = v.trim();
+  if (!trimmed) return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
+export default function ProfileClient({ initial }: ProfileClientProps) {
+  const [values, setValues] = useState(() => ({
+    name: initial.name,
+    birthDate: initial.birthDate,
+    height: initial.height === null ? "" : String(initial.height),
+    targetWeight:
+      initial.targetWeight === null ? "" : String(initial.targetWeight),
+    restingHRBase:
+      initial.restingHRBase === null ? "" : String(initial.restingHRBase),
+    maxHR: initial.maxHR === null ? "" : String(initial.maxHR),
+    lthr: initial.lthr === null ? "" : String(initial.lthr),
+    lthrPace: formatPace(initial.lthrPace),
+    targetCalories:
+      initial.targetCalories === null ? "" : String(initial.targetCalories),
+  }));
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  function setField<K extends keyof typeof values>(
+    key: K,
+    value: (typeof values)[K]
+  ) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setMessage(null);
+
+    const pace = values.lthrPace ? parsePace(values.lthrPace) : null;
+    if (values.lthrPace && pace === null) {
+      setMessage({ type: "error", text: "LTHR 페이스는 M:SS 형식이어야 합니다" });
+      return;
+    }
+
+    const payload = {
+      name: values.name.trim() || "사용자",
+      birthDate: values.birthDate || null,
+      height: toNumOrNull(values.height),
+      targetWeight: toNumOrNull(values.targetWeight),
+      restingHRBase: toNumOrNull(values.restingHRBase),
+      maxHR: toNumOrNull(values.maxHR),
+      lthr: toNumOrNull(values.lthr),
+      lthrPace: pace,
+      targetCalories: toNumOrNull(values.targetCalories),
+    };
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/profile", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage({
+          type: "error",
+          text: data?.error ?? "저장 실패",
+        });
+        return;
+      }
+      setMessage({ type: "success", text: "저장되었습니다" });
+    } catch (err) {
+      setMessage({
+        type: "error",
+        text: err instanceof Error ? err.message : "네트워크 오류",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="max-w-2xl">
+      <div className="mb-8">
+        <h1 className="text-2xl font-semibold mb-1">프로필 설정</h1>
+        <p className="text-dim text-sm">
+          개인 심박 Zone, 칼로리 목표 등을 관리합니다
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-8">
+        {/* 기본 정보 */}
+        <section className="space-y-4">
+          <h2 className="text-sm text-muted uppercase tracking-wider">
+            기본 정보
+          </h2>
+
+          <Field label="이름">
+            <input
+              type="text"
+              value={values.name}
+              onChange={(e) => setField("name", e.target.value)}
+              className={INPUT_CLASS}
+              maxLength={100}
+            />
+          </Field>
+
+          <Field label="생년월일">
+            <input
+              type="date"
+              value={values.birthDate}
+              onChange={(e) => setField("birthDate", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Field label="키 (cm)">
+              <input
+                type="number"
+                step="0.1"
+                value={values.height}
+                onChange={(e) => setField("height", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+            <Field label="목표 체중 (kg)">
+              <input
+                type="number"
+                step="0.1"
+                value={values.targetWeight}
+                onChange={(e) => setField("targetWeight", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          </div>
+        </section>
+
+        {/* 심박 Zone */}
+        <section className="space-y-4">
+          <div>
+            <h2 className="text-sm text-muted uppercase tracking-wider">
+              심박 Zone
+            </h2>
+            <p className="text-xs text-dim mt-1">
+              실측값을 입력하면 러닝 분석·AI 리포트가 개인화됩니다
+            </p>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Field
+              label="최대 심박 (bpm)"
+              hint="최대 노력 런 마지막 1분 평균 또는 Garmin 최고 기록"
+            >
+              <input
+                type="number"
+                value={values.maxHR}
+                onChange={(e) => setField("maxHR", e.target.value)}
+                className={INPUT_CLASS}
+                min={100}
+                max={230}
+              />
+            </Field>
+            <Field
+              label="안정시 심박 (bpm)"
+              hint="아침 기상 직후 측정한 안정시 심박 기준값"
+            >
+              <input
+                type="number"
+                value={values.restingHRBase}
+                onChange={(e) => setField("restingHRBase", e.target.value)}
+                className={INPUT_CLASS}
+                min={20}
+                max={150}
+              />
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+            <Field
+              label="LTHR (bpm)"
+              hint="20분 TT 평균 심박 × 0.95 또는 Garmin 트레이닝 스테이터스"
+            >
+              <input
+                type="number"
+                value={values.lthr}
+                onChange={(e) => setField("lthr", e.target.value)}
+                className={INPUT_CLASS}
+                min={60}
+                max={220}
+              />
+            </Field>
+            <Field label="LTHR 페이스 (M:SS /km)">
+              <input
+                type="text"
+                placeholder="5:21"
+                value={values.lthrPace}
+                onChange={(e) => setField("lthrPace", e.target.value)}
+                className={INPUT_CLASS}
+              />
+            </Field>
+          </div>
+        </section>
+
+        {/* 칼로리 목표 */}
+        <section className="space-y-4">
+          <h2 className="text-sm text-muted uppercase tracking-wider">
+            칼로리 목표
+          </h2>
+
+          <Field
+            label="일일 칼로리 목표 (kcal)"
+            hint="체중감량 목표에 맞는 기본 섭취 칼로리. 활성 칼로리와 합산하여 섭취가능 칼로리 계산"
+          >
+            <input
+              type="number"
+              value={values.targetCalories}
+              onChange={(e) => setField("targetCalories", e.target.value)}
+              className={INPUT_CLASS}
+              min={500}
+              max={8000}
+            />
+          </Field>
+        </section>
+
+        {/* 저장 영역 */}
+        <div className="flex items-center gap-3 pt-4 border-t border-[#1e1e1e]">
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-5 py-2.5 rounded-md bg-accent text-black text-sm font-medium disabled:opacity-50 disabled:cursor-not-allowed transition-opacity"
+          >
+            {saving ? "저장 중..." : "저장"}
+          </button>
+          {message && (
+            <span
+              className={`text-sm ${
+                message.type === "success" ? "text-accent" : "text-red-400"
+              }`}
+              role="status"
+            >
+              {message.text}
+            </span>
+          )}
+        </div>
+      </form>
+    </div>
+  );
+}
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 rounded-md bg-card border border-[#1e1e1e] text-bright text-sm focus:outline-none focus:border-accent/60 transition-colors";
+
+interface FieldProps {
+  label: string;
+  hint?: string;
+  children: React.ReactNode;
+}
+
+function Field({ label, hint, children }: FieldProps) {
+  return (
+    <label className="block">
+      <div className="text-xs text-sub mb-1.5">{label}</div>
+      {children}
+      {hint && <div className="text-[11px] text-dim mt-1">{hint}</div>}
+    </label>
+  );
+}

--- a/src/app/settings/profile/profile-client.tsx
+++ b/src/app/settings/profile/profile-client.tsx
@@ -30,11 +30,12 @@ function parsePace(input: string): number | null {
   return min * 60 + sec;
 }
 
-/** sec → "M:SS" */
+/** sec → "M:SS" (반올림으로 60초 발생 방지) */
 function formatPace(sec: number | null): string {
   if (sec === null || !Number.isFinite(sec) || sec <= 0) return "";
-  const min = Math.floor(sec / 60);
-  const s = Math.round(sec - min * 60);
+  const total = Math.round(sec);
+  const min = Math.floor(total / 60);
+  const s = total % 60;
   return `${min}:${String(s).padStart(2, "0")}`;
 }
 
@@ -200,7 +201,7 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
                 onChange={(e) => setField("maxHR", e.target.value)}
                 className={INPUT_CLASS}
                 min={100}
-                max={230}
+                max={220}
               />
             </Field>
             <Field
@@ -228,7 +229,7 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
                 value={values.lthr}
                 onChange={(e) => setField("lthr", e.target.value)}
                 className={INPUT_CLASS}
-                min={60}
+                min={80}
                 max={220}
               />
             </Field>
@@ -260,7 +261,7 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
               onChange={(e) => setField("targetCalories", e.target.value)}
               className={INPUT_CLASS}
               min={500}
-              max={8000}
+              max={5000}
             />
           </Field>
         </section>

--- a/src/components/activity/RunningAnalysis.tsx
+++ b/src/components/activity/RunningAnalysis.tsx
@@ -2,6 +2,7 @@
 
 import TrendLineChart from "@/components/ui/TrendLineChart";
 import { formatPace } from "@/lib/format";
+import { calculateHRZone } from "@/lib/fitness/zones";
 
 interface RunningRecord {
   date: string;
@@ -16,36 +17,33 @@ interface RunningRecord {
 interface RunningAnalysisProps {
   records: RunningRecord[];
   estimatedMaxHR: number;
+  /** 사용자 실측 LTHR. 있으면 LTHR 기반, 없으면 maxHR × 0.9 근사. */
+  userLTHR?: number | null;
 }
 
-const HR_ZONES = [
-  { zone: 1, label: "회복", range: [0.5, 0.6], color: "#a3a3a3" },
-  { zone: 2, label: "이지", range: [0.6, 0.7], color: "#22c55e" },
-  { zone: 3, label: "에어로빅", range: [0.7, 0.8], color: "#60a5fa" },
-  { zone: 4, label: "템포", range: [0.8, 0.9], color: "#f59e0b" },
-  { zone: 5, label: "인터벌", range: [0.9, 1.0], color: "#ef4444" },
+const HR_ZONE_META = [
+  { zone: 1, label: "회복", color: "#a3a3a3" },
+  { zone: 2, label: "이지", color: "#22c55e" },
+  { zone: 3, label: "에어로빅", color: "#60a5fa" },
+  { zone: 4, label: "역치", color: "#f59e0b" },
+  { zone: 5, label: "VO2max", color: "#ef4444" },
 ];
-
-function getZone(hr: number, maxHR: number): number {
-  const pct = hr / maxHR;
-  if (pct >= 0.9) return 5;
-  if (pct >= 0.8) return 4;
-  if (pct >= 0.7) return 3;
-  if (pct >= 0.6) return 2;
-  return 1;
-}
 
 export default function RunningAnalysis({
   records,
   estimatedMaxHR,
+  userLTHR,
 }: RunningAnalysisProps) {
+  // LTHR 결정: 사용자 실측 → maxHR × 0.9 근사
+  const lthr = userLTHR && userLTHR > 0 ? userLTHR : Math.round(estimatedMaxHR * 0.9);
+  const isMeasured = Boolean(userLTHR && userLTHR > 0);
   if (records.length === 0) return null;
 
-  // HR존 분포
+  // HR존 분포 (LTHR 기반)
   const zoneCounts = [0, 0, 0, 0, 0];
   const withHR = records.filter((r) => r.avgHR !== null);
   for (const r of withHR) {
-    const z = getZone(r.avgHR!, estimatedMaxHR);
+    const z = calculateHRZone(r.avgHR!, lthr);
     zoneCounts[z - 1]++;
   }
   const totalWithHR = withHR.length || 1;
@@ -79,7 +77,7 @@ export default function RunningAnalysis({
           HR존 분포 ({withHR.length}회 러닝)
         </div>
         <div className="space-y-2">
-          {HR_ZONES.map((z, i) => {
+          {HR_ZONE_META.map((z, i) => {
             const pct = Math.round((zoneCounts[i] / totalWithHR) * 100);
             return (
               <div key={z.zone} className="flex items-center gap-3">
@@ -103,7 +101,10 @@ export default function RunningAnalysis({
           })}
         </div>
         <div className="text-[10px] text-dim mt-3">
-          추정 최대 심박: {estimatedMaxHR} bpm
+          {isMeasured
+            ? `LTHR ${lthr} bpm (실측)`
+            : `LTHR ${lthr} bpm (최대심박 × 0.9 추정)`}
+          {" · "}최대 심박 {estimatedMaxHR} bpm
         </div>
       </div>
 

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -98,6 +98,16 @@ const NAV_ITEMS: NavItem[] = [
       </svg>
     ),
   },
+  {
+    label: "설정",
+    href: "/settings/profile",
+    icon: (
+      <svg width="20" height="20" viewBox="0 0 20 20" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+        <circle cx="10" cy="10" r="2.5" />
+        <path d="M10 1v2M10 17v2M4.2 4.2l1.4 1.4M14.4 14.4l1.4 1.4M1 10h2M17 10h2M4.2 15.8l1.4-1.4M14.4 5.6l1.4-1.4" />
+      </svg>
+    ),
+  },
 ];
 
 interface SidebarProps {

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -75,28 +75,36 @@ function formatKSTDateTime(): string {
 }
 
 async function buildUserProfileSection(): Promise<string> {
+  // 프로필 row가 없어도 fallback Zone(190 bpm 기본)을 출력해야 함.
+  // 신규 DB에서 /api/profile 호출 전이라도 AI가 Zone 인지 응답을 하도록.
   const profile = await prisma.userProfile.findFirst();
-  if (!profile) return "";
 
   const lines: string[] = ["## 사용자 프로필"];
 
-  if (profile.maxHR) lines.push(`- 최대 심박: ${profile.maxHR} bpm (실측)`);
-  if (profile.lthr) lines.push(`- LTHR: ${profile.lthr} bpm (실측)`);
-  if (profile.lthrPace) {
+  if (profile?.maxHR) lines.push(`- 최대 심박: ${profile.maxHR} bpm (실측)`);
+  if (profile?.lthr) lines.push(`- LTHR: ${profile.lthr} bpm (실측)`);
+  if (profile?.lthrPace) {
     const totalSec = Math.round(profile.lthrPace);
     const min = Math.floor(totalSec / 60);
     const sec = totalSec % 60;
     lines.push(`- LTHR 페이스: ${min}:${String(sec).padStart(2, "0")}/km`);
   }
-  if (profile.targetCalories)
+  if (profile?.targetCalories)
     lines.push(`- 일일 칼로리 목표: ${profile.targetCalories} kcal`);
-  if (profile.targetWeight)
+  if (profile?.targetWeight)
     lines.push(`- 목표 체중: ${profile.targetWeight} kg`);
 
-  // 개인 Zone: 실측 LTHR 우선, 없으면 나이/maxHR 기반 fallback
-  const maxHR = resolveMaxHR(profile);
-  const lthr = resolveLTHR(profile);
-  const isMeasuredLthr = Boolean(profile.lthr && profile.lthr > 0);
+  // 프로필 정보가 하나도 없으면 안내 추가
+  if (lines.length === 1) {
+    lines.push(
+      "- (프로필 미설정 — /settings/profile 에서 maxHR, LTHR 등을 입력하면 정확도가 향상됩니다)"
+    );
+  }
+
+  // 개인 Zone: 실측 LTHR 우선, 없으면 나이/maxHR 기반 fallback (190 bpm 기본)
+  const maxHR = resolveMaxHR(profile ?? {});
+  const lthr = resolveLTHR(profile ?? {});
+  const isMeasuredLthr = Boolean(profile?.lthr && profile.lthr > 0);
   const zones = getZoneRanges(lthr, maxHR);
   lines.push("");
   lines.push(

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -83,8 +83,9 @@ async function buildUserProfileSection(): Promise<string> {
   if (profile.maxHR) lines.push(`- 최대 심박: ${profile.maxHR} bpm (실측)`);
   if (profile.lthr) lines.push(`- LTHR: ${profile.lthr} bpm (실측)`);
   if (profile.lthrPace) {
-    const min = Math.floor(profile.lthrPace / 60);
-    const sec = Math.round(profile.lthrPace - min * 60);
+    const totalSec = Math.round(profile.lthrPace);
+    const min = Math.floor(totalSec / 60);
+    const sec = totalSec % 60;
     lines.push(`- LTHR 페이스: ${min}:${String(sec).padStart(2, "0")}/km`);
   }
   if (profile.targetCalories)
@@ -92,24 +93,25 @@ async function buildUserProfileSection(): Promise<string> {
   if (profile.targetWeight)
     lines.push(`- 목표 체중: ${profile.targetWeight} kg`);
 
-  // 개인 Zone 기준 (LTHR 있을 때만)
-  if (profile.lthr) {
-    const maxHR = resolveMaxHR(profile);
-    const lthr = resolveLTHR(profile);
-    const zones = getZoneRanges(lthr, maxHR);
-    lines.push("");
-    lines.push(
-      "## 개인 HR Zone (LTHR 기반, 러닝 분석 시 아래 값 우선)"
-    );
-    for (const z of zones) {
-      const range =
-        z.min === null
-          ? `<${(z.max ?? 0) + 1} bpm`
-          : z.max === null
-            ? `${z.min}+ bpm`
-            : `${z.min}-${z.max} bpm`;
-      lines.push(`- Zone ${z.zone} (${z.label}): ${range}`);
-    }
+  // 개인 Zone: 실측 LTHR 우선, 없으면 나이/maxHR 기반 fallback
+  const maxHR = resolveMaxHR(profile);
+  const lthr = resolveLTHR(profile);
+  const isMeasuredLthr = Boolean(profile.lthr && profile.lthr > 0);
+  const zones = getZoneRanges(lthr, maxHR);
+  lines.push("");
+  lines.push(
+    `## 개인 HR Zone (${
+      isMeasuredLthr ? "LTHR 실측 기반" : "추정값, 참고용"
+    }, 러닝 분석 시 아래 값 우선)`
+  );
+  for (const z of zones) {
+    const range =
+      z.min === null
+        ? `<${(z.max ?? 0) + 1} bpm`
+        : z.max === null
+          ? `${z.min}+ bpm`
+          : `${z.min}-${z.max} bpm`;
+    lines.push(`- Zone ${z.zone} (${z.label}): ${range}`);
   }
 
   return lines.join("\n") + "\n";

--- a/src/lib/ai/system-prompt.ts
+++ b/src/lib/ai/system-prompt.ts
@@ -1,3 +1,6 @@
+import prisma from "@/lib/prisma";
+import { getZoneRanges, resolveLTHR, resolveMaxHR } from "@/lib/fitness/zones";
+
 const BASE_PROMPT = `당신은 개인 피트니스 AI 어드바이저입니다.
 
 ## 역할
@@ -71,6 +74,48 @@ function formatKSTDateTime(): string {
   return `${y}년 ${m}월 ${d}일 ${dayName}요일 ${h}:${min} KST`;
 }
 
+async function buildUserProfileSection(): Promise<string> {
+  const profile = await prisma.userProfile.findFirst();
+  if (!profile) return "";
+
+  const lines: string[] = ["## 사용자 프로필"];
+
+  if (profile.maxHR) lines.push(`- 최대 심박: ${profile.maxHR} bpm (실측)`);
+  if (profile.lthr) lines.push(`- LTHR: ${profile.lthr} bpm (실측)`);
+  if (profile.lthrPace) {
+    const min = Math.floor(profile.lthrPace / 60);
+    const sec = Math.round(profile.lthrPace - min * 60);
+    lines.push(`- LTHR 페이스: ${min}:${String(sec).padStart(2, "0")}/km`);
+  }
+  if (profile.targetCalories)
+    lines.push(`- 일일 칼로리 목표: ${profile.targetCalories} kcal`);
+  if (profile.targetWeight)
+    lines.push(`- 목표 체중: ${profile.targetWeight} kg`);
+
+  // 개인 Zone 기준 (LTHR 있을 때만)
+  if (profile.lthr) {
+    const maxHR = resolveMaxHR(profile);
+    const lthr = resolveLTHR(profile);
+    const zones = getZoneRanges(lthr, maxHR);
+    lines.push("");
+    lines.push(
+      "## 개인 HR Zone (LTHR 기반, 러닝 분석 시 아래 값 우선)"
+    );
+    for (const z of zones) {
+      const range =
+        z.min === null
+          ? `<${(z.max ?? 0) + 1} bpm`
+          : z.max === null
+            ? `${z.min}+ bpm`
+            : `${z.min}-${z.max} bpm`;
+      lines.push(`- Zone ${z.zone} (${z.label}): ${range}`);
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}
+
 export async function buildSystemPrompt(): Promise<string> {
-  return `${BASE_PROMPT}\n## 현재 시간\n${formatKSTDateTime()}\n`;
+  const profileSection = await buildUserProfileSection();
+  return `${BASE_PROMPT}\n${profileSection}## 현재 시간\n${formatKSTDateTime()}\n`;
 }

--- a/src/lib/fitness/zones.ts
+++ b/src/lib/fitness/zones.ts
@@ -1,0 +1,100 @@
+/**
+ * LTHR(젖산역치 심박수) 기반 HR Zone 계산.
+ *
+ * Zone 기준 (Joe Friel, "Training and Racing with a Power Meter" 및 The Triathlete's Training Bible):
+ * - Zone 1: < 80% LTHR (회복)
+ * - Zone 2: 80-89% LTHR (이지런, 유산소 베이스)
+ * - Zone 3: 89-94% LTHR (에어로빅/템포)
+ * - Zone 4: 94-99% LTHR (역치)
+ * - Zone 5: ≥ 100% LTHR (VO2max/무산소)
+ */
+
+export type HRZone = 1 | 2 | 3 | 4 | 5;
+
+export const ZONE_BOUNDARIES = [0.8, 0.89, 0.94, 1.0] as const;
+
+export interface ZoneRange {
+  zone: HRZone;
+  min: number | null; // 최소 bpm (null = 하한 없음)
+  max: number | null; // 최대 bpm (null = 상한 없음)
+  label: string;
+}
+
+/** HR이 속한 Zone 번호 반환 (1~5) */
+export function calculateHRZone(hr: number, lthr: number): HRZone {
+  if (lthr <= 0) throw new Error("LTHR must be positive");
+  const pct = hr / lthr;
+  if (pct >= ZONE_BOUNDARIES[3]) return 5;
+  if (pct >= ZONE_BOUNDARIES[2]) return 4;
+  if (pct >= ZONE_BOUNDARIES[1]) return 3;
+  if (pct >= ZONE_BOUNDARIES[0]) return 2;
+  return 1;
+}
+
+/** LTHR 기반 Zone 경계 bpm 배열 */
+export function getZoneRanges(lthr: number, maxHR?: number | null): ZoneRange[] {
+  if (lthr <= 0) throw new Error("LTHR must be positive");
+  const b = ZONE_BOUNDARIES.map((r) => Math.round(lthr * r));
+  return [
+    { zone: 1, min: null, max: b[0] - 1, label: "회복" },
+    { zone: 2, min: b[0], max: b[1] - 1, label: "이지런" },
+    { zone: 3, min: b[1], max: b[2] - 1, label: "에어로빅" },
+    { zone: 4, min: b[2], max: b[3] - 1, label: "역치" },
+    { zone: 5, min: b[3], max: maxHR ?? null, label: "VO2max" },
+  ];
+}
+
+/** HR 시계열 → Zone별 초 합계 */
+export function computeZoneDistribution(
+  hrSeries: readonly number[],
+  lthr: number
+): Record<`z${HRZone}`, number> {
+  const dist = { z1: 0, z2: 0, z3: 0, z4: 0, z5: 0 };
+  for (const hr of hrSeries) {
+    if (!Number.isFinite(hr) || hr <= 0) continue;
+    const z = calculateHRZone(hr, lthr);
+    dist[`z${z}` as const]++;
+  }
+  return dist;
+}
+
+/** Zone별 백분율 (합계 100) */
+export function zoneDistributionPercent(
+  dist: Record<`z${HRZone}`, number>
+): Record<`z${HRZone}`, number> {
+  const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
+  if (total === 0) return { z1: 0, z2: 0, z3: 0, z4: 0, z5: 0 };
+  return {
+    z1: Number(((dist.z1 / total) * 100).toFixed(1)),
+    z2: Number(((dist.z2 / total) * 100).toFixed(1)),
+    z3: Number(((dist.z3 / total) * 100).toFixed(1)),
+    z4: Number(((dist.z4 / total) * 100).toFixed(1)),
+    z5: Number(((dist.z5 / total) * 100).toFixed(1)),
+  };
+}
+
+/** maxHR fallback: UserProfile.maxHR → 220 - age → 190 */
+export function resolveMaxHR(profile: {
+  maxHR?: number | null;
+  birthDate?: Date | null;
+}): number {
+  if (profile.maxHR && profile.maxHR > 0) return profile.maxHR;
+  if (profile.birthDate) {
+    const age = Math.floor(
+      (Date.now() - profile.birthDate.getTime()) /
+        (365.25 * 24 * 60 * 60 * 1000)
+    );
+    if (age > 0 && age < 120) return 220 - age;
+  }
+  return 190;
+}
+
+/** LTHR fallback: UserProfile.lthr → maxHR × 0.9 */
+export function resolveLTHR(profile: {
+  lthr?: number | null;
+  maxHR?: number | null;
+  birthDate?: Date | null;
+}): number {
+  if (profile.lthr && profile.lthr > 0) return profile.lthr;
+  return Math.round(resolveMaxHR(profile) * 0.9);
+}


### PR DESCRIPTION
## 변경 사항

UserProfile에 실측 심박 지표(maxHR, LTHR, lthrPace)와 칼로리 목표(targetCalories)를 저장하고, 러닝 분석·AI 리포트가 개인 Zone을 사용하도록 변경.

### 추가
- `UserProfile.maxHR / lthr / lthrPace / targetCalories` 컬럼 + `singleton` unique 제약
- `src/lib/fitness/zones.ts` — LTHR 기반 Zone 계산 유틸 + maxHR/LTHR resolver
- `/api/profile` GET/PATCH (Zod 검증, 싱글톤 upsert)
- `/settings/profile` 페이지 + 사이드바 "설정" 메뉴
- AI 시스템 프롬프트에 사용자 프로필/Zone 섹션 주입 (LTHR 미입력자도 추정 Zone 표기)
- 마이그레이션 2건 (`add_user_zones`, `add_user_profile_singleton` — dedupe step 포함)

### 변경
- `RunningAnalysis` 컴포넌트: maxHR 비율 → LTHR 기반 Zone으로 전환

Closes #53

## 디자인
`docs/designs/53-m4-1-profile/design-notes.md`

## 스펙
`docs/specs/m4-1-maxhr-lthr.md`

## 체크리스트
- [x] `npm run lint`
- [x] `npx tsc --noEmit`
- [x] `npm run build`
- [x] 코드 리뷰 통과 (codex-cli, reasoningEffort=high)

## 코드 리뷰 결과
- 라운드 1: P1 4건 (날짜 검증, LTHR 검증, 입력 범위, Zone 주입 누락) → 수정
- 라운드 2: P2 1건 (UserProfile 싱글톤 미보장) → schema unique + upsert로 수정
- 라운드 3: P1 1건 (마이그레이션 dedupe 누락) → SQL 보강
- 라운드 4: **P0/P1/P2 모두 0건 ✅**

## 테스트 플랜
- [ ] `/settings/profile` 진입 → 폼 렌더링 확인
- [ ] maxHR=176, LTHR=157, LTHR 페이스 5:21, 목표 칼로리 1890 입력 후 저장
- [ ] LTHR > maxHR 입력 시 400 에러 메시지 노출
- [ ] 비정상 생년월일(2024-02-31) 입력 시 거부
- [ ] `/activities` HR존 분포가 LTHR 기반(157)으로 변경됐는지 확인 — "LTHR 157 bpm (실측)" 라벨
- [ ] AI 어드바이저에 "내 Zone 알려줘" 질문 → 개인 Zone 응답 확인