### PR TITLE
[M4-2] 칼로리 밸런스 필드 추가 (#55)

### DIFF
--- a/prisma/migrations/20260416092021_add_calorie_balance/migration.sql
+++ b/prisma/migrations/20260416092021_add_calorie_balance/migration.sql
@@ -1,0 +1,5 @@
+-- AlterTable: M4-2 칼로리 밸런스 필드
+ALTER TABLE "DailySummary"
+  ADD COLUMN "estimatedIntakeCalories" INTEGER,
+  ADD COLUMN "availableCalories" INTEGER,
+  ADD COLUMN "calorieBalance" INTEGER;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -91,6 +91,10 @@ model DailySummary {
   stressLowDuration   Int?             // minutes
   bodyBatteryCharged  Int?             // 충전량
   bodyBatteryDrained  Int?             // 소모량
+  // M4-2: 칼로리 밸런스
+  estimatedIntakeCalories Int?         // 섭취 칼로리 (FoodLog 합계 또는 MFP)
+  availableCalories       Int?         // 목표 + 활성
+  calorieBalance          Int?         // 섭취 - 섭취가능 (음수 = 결손/감량)
   rawData         Json?
   createdAt       DateTime @default(now())
 }

--- a/src/app/api/food/route.ts
+++ b/src/app/api/food/route.ts
@@ -1,6 +1,28 @@
 import { NextResponse } from "next/server";
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { recalculateCalorieBalance } from "@/lib/fitness/calorie-balance";
+
+const MAX_RETRY = 3;
+const RETRY_DELAY_MS = 50;
+
+async function withSerializableRetry<T>(
+  fn: (tx: Prisma.TransactionClient) => Promise<T>
+): Promise<T> {
+  for (let attempt = 1; attempt <= MAX_RETRY; attempt++) {
+    try {
+      return await prisma.$transaction(fn, {
+        isolationLevel: "Serializable",
+      });
+    } catch (err) {
+      const isSerializationFailure =
+        err instanceof Error && err.message.includes("P2034");
+      if (!isSerializationFailure || attempt === MAX_RETRY) throw err;
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * attempt));
+    }
+  }
+  throw new Error("Serializable retry exhausted");
+}
 
 export async function GET(request: Request) {
   try {
@@ -55,22 +77,19 @@ export async function POST(request: Request) {
     }
 
     // M4-2: FoodLog 생성 + 칼로리 밸런스 재계산을 Serializable 트랜잭션에서 원자화.
-    // 재계산 실패 시 create도 롤백되어 클라이언트 재시도 시 중복 입력을 방지.
-    const log = await prisma.$transaction(
-      async (tx) => {
-        const created = await tx.foodLog.create({
-          data: {
-            date: foodDate,
-            description,
-            estimatedKcal,
-            mealType: mealType ?? null,
-          },
-        });
-        await recalculateCalorieBalance(foodDate, tx);
-        return created;
-      },
-      { isolationLevel: "Serializable" }
-    );
+    // 직렬화 충돌(P2034) 시 자동 재시도로 동시 요청 안전 보장.
+    const log = await withSerializableRetry(async (tx) => {
+      const created = await tx.foodLog.create({
+        data: {
+          date: foodDate,
+          description,
+          estimatedKcal,
+          mealType: mealType ?? null,
+        },
+      });
+      await recalculateCalorieBalance(foodDate, tx);
+      return created;
+    });
 
     return NextResponse.json({
       data: {

--- a/src/app/api/food/route.ts
+++ b/src/app/api/food/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
+import { recalculateCalorieBalance } from "@/lib/fitness/calorie-balance";
 
 export async function GET(request: Request) {
   try {
@@ -61,6 +62,9 @@ export async function POST(request: Request) {
         mealType: mealType ?? null,
       },
     });
+
+    // M4-2: 칼로리 밸런스 재계산 (섭취 칼로리 변화 반영)
+    await recalculateCalorieBalance(foodDate);
 
     return NextResponse.json({
       data: {

--- a/src/app/api/food/route.ts
+++ b/src/app/api/food/route.ts
@@ -54,17 +54,23 @@ export async function POST(request: Request) {
       }
     }
 
-    const log = await prisma.foodLog.create({
-      data: {
-        date: foodDate,
-        description,
-        estimatedKcal,
-        mealType: mealType ?? null,
+    // M4-2: FoodLog 생성 + 칼로리 밸런스 재계산을 Serializable 트랜잭션에서 원자화.
+    // 재계산 실패 시 create도 롤백되어 클라이언트 재시도 시 중복 입력을 방지.
+    const log = await prisma.$transaction(
+      async (tx) => {
+        const created = await tx.foodLog.create({
+          data: {
+            date: foodDate,
+            description,
+            estimatedKcal,
+            mealType: mealType ?? null,
+          },
+        });
+        await recalculateCalorieBalance(foodDate, tx);
+        return created;
       },
-    });
-
-    // M4-2: 칼로리 밸런스 재계산 (섭취 칼로리 변화 반영)
-    await recalculateCalorieBalance(foodDate);
+      { isolationLevel: "Serializable" }
+    );
 
     return NextResponse.json({
       data: {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import prisma from "@/lib/prisma";
 import { resolveMaxHR } from "@/lib/fitness/zones";
+import { recalculateAllCalorieBalances } from "@/lib/fitness/calorie-balance";
 
 /** "YYYY-MM-DD" 형식이면서 실제 달력상 유효한 날짜인지 검증 */
 const birthDateSchema = z
@@ -120,6 +121,23 @@ export async function PATCH(request: Request) {
       where: { id: existing.id },
       data: updatePayload,
     });
+
+    // M4-2: targetCalories 변경 시 모든 DailySummary의 칼로리 밸런스 재계산
+    // (stale availableCalories/calorieBalance 방지)
+    const targetCaloriesChanged =
+      data.targetCalories !== undefined &&
+      data.targetCalories !== existing.targetCalories;
+    if (targetCaloriesChanged) {
+      try {
+        await recalculateAllCalorieBalances();
+      } catch (err) {
+        // 재계산 실패는 프로필 저장을 실패시키지 않음 (cron에서 자연 복구)
+        console.error(
+          "[profile] 프로필 변경 후 칼로리 재계산 실패:",
+          err instanceof Error ? err.message : String(err)
+        );
+      }
+    }
 
     return NextResponse.json({ profile });
   } catch (error) {

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -122,21 +122,25 @@ export async function PATCH(request: Request) {
       data: updatePayload,
     });
 
-    // M4-2: targetCalories 변경 시 모든 DailySummary의 칼로리 밸런스 재계산
-    // (stale availableCalories/calorieBalance 방지)
+    // M4-2: targetCalories 변경 시 모든 DailySummary의 칼로리 밸런스 재계산.
+    // 히스토리가 수백 건이면 수 초 이상 걸릴 수 있으므로 fire-and-forget으로 백그라운드 실행.
+    // (Node 런타임에서 프로세스가 계속 살아있으므로 완료 보장, 실패해도 다음 싱크/수동 재계산으로 복구)
     const targetCaloriesChanged =
       data.targetCalories !== undefined &&
       data.targetCalories !== existing.targetCalories;
     if (targetCaloriesChanged) {
-      try {
-        await recalculateAllCalorieBalances();
-      } catch (err) {
-        // 재계산 실패는 프로필 저장을 실패시키지 않음 (cron에서 자연 복구)
-        console.error(
-          "[profile] 프로필 변경 후 칼로리 재계산 실패:",
-          err instanceof Error ? err.message : String(err)
-        );
-      }
+      recalculateAllCalorieBalances()
+        .then(({ processed, failed }) => {
+          console.log(
+            `[profile] targetCalories 변경 → 백그라운드 재계산: ${processed}건 성공, ${failed}건 실패`
+          );
+        })
+        .catch((err) => {
+          console.error(
+            "[profile] 프로필 변경 후 칼로리 재계산 실패:",
+            err instanceof Error ? err.message : String(err)
+          );
+        });
     }
 
     return NextResponse.json({ profile });

--- a/src/app/dashboard-client.tsx
+++ b/src/app/dashboard-client.tsx
@@ -12,6 +12,10 @@ interface DaySummary {
   sleepScore: number | null;
   bodyBattery: number | null;
   spo2: number | null;
+  intakeCalories: number | null;
+  availableCalories: number | null;
+  calorieBalance: number | null;
+  activeCalories: number | null;
 }
 
 interface DataPoint {
@@ -234,6 +238,13 @@ export default function DashboardClient({
         )}
       </div>
 
+      {/* 칼로리 밸런스 (M4-2) */}
+      {(today.calorieBalance !== null ||
+        today.intakeCalories !== null ||
+        today.availableCalories !== null) && (
+        <CalorieBalanceCard today={today} yesterday={yesterday} />
+      )}
+
       {/* 주간 차트 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-3">
         <WeeklyChart title="주간 걸음 수" data={weeklySteps} color="#22c55e" />
@@ -288,6 +299,98 @@ export default function DashboardClient({
         />
         <StressDetailChart data={monthlyStressDetail} />
       </div>
+    </div>
+  );
+}
+
+function CalorieBalanceCard({
+  today,
+  yesterday,
+}: {
+  today: DaySummary;
+  yesterday: DaySummary;
+}) {
+  const balance = today.calorieBalance;
+  const intake = today.intakeCalories;
+  const available = today.availableCalories;
+  const active = today.activeCalories;
+
+  // 결손(음수)은 감량 페이스 → 초록, 잉여(양수)는 빨강
+  const balanceColor =
+    balance === null
+      ? "text-dim"
+      : balance <= -1000
+        ? "text-yellow-400"
+        : balance < 0
+          ? "text-accent"
+          : "text-red-400";
+
+  const balanceText =
+    balance === null
+      ? "—"
+      : balance < 0
+        ? `${balance.toLocaleString("ko-KR")} kcal 결손`
+        : balance === 0
+          ? "균형"
+          : `+${balance.toLocaleString("ko-KR")} kcal 잉여`;
+
+  const yBalance = yesterday.calorieBalance;
+  const yBalanceText =
+    yBalance === null
+      ? null
+      : yBalance < 0
+        ? `어제 ${yBalance.toLocaleString("ko-KR")} kcal`
+        : `어제 +${yBalance.toLocaleString("ko-KR")} kcal`;
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-5 mb-3">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[11px] text-dim tracking-wider uppercase">
+          칼로리 밸런스
+        </div>
+        {yBalanceText && (
+          <div className="text-[10px] text-dim">{yBalanceText}</div>
+        )}
+      </div>
+
+      <div className={`text-2xl font-semibold mb-4 ${balanceColor}`}>
+        {balanceText}
+      </div>
+
+      <div className="grid grid-cols-3 gap-3 text-[11px]">
+        <div>
+          <div className="text-dim mb-1">섭취</div>
+          <div className="font-[family-name:var(--font-geist-mono)] text-bright">
+            {intake !== null
+              ? `${intake.toLocaleString("ko-KR")} kcal`
+              : "—"}
+          </div>
+        </div>
+        <div>
+          <div className="text-dim mb-1">섭취가능 (목표+활성)</div>
+          <div className="font-[family-name:var(--font-geist-mono)] text-bright">
+            {available !== null
+              ? `${available.toLocaleString("ko-KR")} kcal`
+              : "—"}
+          </div>
+        </div>
+        <div>
+          <div className="text-dim mb-1">활성</div>
+          <div className="font-[family-name:var(--font-geist-mono)] text-bright">
+            {active !== null
+              ? `${active.toLocaleString("ko-KR")} kcal`
+              : "—"}
+          </div>
+        </div>
+      </div>
+
+      {(intake === null || available === null) && (
+        <div className="text-[10px] text-dim mt-3">
+          {available === null && "목표 칼로리 미설정 — /settings/profile 에서 입력하면 밸런스가 계산됩니다"}
+          {available === null && intake === null && " · "}
+          {intake === null && "오늘 식단 기록 없음"}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -82,6 +82,10 @@ export default async function DashboardPage() {
     sleepScore: todaySleep?.sleepScore ?? null,
     bodyBattery: todaySummary?.bodyBattery ?? null,
     spo2: todaySleep?.avgSpO2 ?? todaySummary?.avgSpo2 ?? null,
+    intakeCalories: todaySummary?.estimatedIntakeCalories ?? null,
+    availableCalories: todaySummary?.availableCalories ?? null,
+    calorieBalance: todaySummary?.calorieBalance ?? null,
+    activeCalories: todaySummary?.activeCalories ?? null,
   };
 
   const yesterdayData = {
@@ -90,6 +94,10 @@ export default async function DashboardPage() {
     sleepScore: yesterdaySleep?.sleepScore ?? null,
     bodyBattery: yesterdaySummary?.bodyBattery ?? null,
     spo2: yesterdaySleep?.avgSpO2 ?? yesterdaySummary?.avgSpo2 ?? null,
+    intakeCalories: yesterdaySummary?.estimatedIntakeCalories ?? null,
+    availableCalories: yesterdaySummary?.availableCalories ?? null,
+    calorieBalance: yesterdaySummary?.calorieBalance ?? null,
+    activeCalories: yesterdaySummary?.activeCalories ?? null,
   };
 
   // 오늘 최신 리포트 (KST 기준, daily-report.ts와 동일 방식)

--- a/src/bot/commands/food.ts
+++ b/src/bot/commands/food.ts
@@ -35,9 +35,9 @@ export async function handleFoodInput(
     },
   });
 
-  // M4-2: 섭취 기록 후 칼로리 밸런스 재계산 (실패해도 봇 응답은 계속)
+  // M4-2: 섭취 기록 후 칼로리 밸런스 재계산 (봇 prisma client 전달, 실패해도 봇 응답은 계속)
   try {
-    await recalculateCalorieBalance(now);
+    await recalculateCalorieBalance(now, undefined, prisma);
   } catch (err) {
     console.error(
       "[bot/food] 칼로리 밸런스 재계산 실패:",

--- a/src/bot/commands/food.ts
+++ b/src/bot/commands/food.ts
@@ -1,4 +1,5 @@
 import prisma from "../prisma";
+import { recalculateCalorieBalance } from "@/lib/fitness/calorie-balance";
 
 const MEAL_PATTERNS = [
   { pattern: /^(아침|조식)/, type: "breakfast" },
@@ -24,14 +25,25 @@ export async function handleFoodInput(
     return;
   }
 
+  const now = new Date();
   await prisma.foodLog.create({
     data: {
-      date: new Date(),
+      date: now,
       description,
       mealType,
       estimatedKcal: null,
     },
   });
+
+  // M4-2: 섭취 기록 후 칼로리 밸런스 재계산 (실패해도 봇 응답은 계속)
+  try {
+    await recalculateCalorieBalance(now);
+  } catch (err) {
+    console.error(
+      "[bot/food] 칼로리 밸런스 재계산 실패:",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
 
   const mealLabels: Record<string, string> = {
     breakfast: "아침", lunch: "점심", dinner: "저녁", snack: "간식",

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -1,0 +1,57 @@
+import prisma from "@/lib/prisma";
+
+/**
+ * 특정 날짜의 칼로리 밸런스를 재계산하여 DailySummary에 저장.
+ *
+ * 계산식:
+ *   availableCalories = targetCalories(프로필) + activeCalories(Garmin)
+ *   estimatedIntakeCalories = SUM(FoodLog.estimatedKcal) for the day
+ *   calorieBalance = intake - available  (음수 = 결손/감량, 양수 = 잉여)
+ *
+ * 프로필/활성 칼로리/섭취 기록 중 하나라도 없으면 해당 값만 null로 저장.
+ */
+export async function recalculateCalorieBalance(
+  date: Date
+): Promise<void> {
+  // 해당 날짜의 midnight 기준 (DailySummary.date는 midnight)
+  const dayStart = new Date(date);
+  dayStart.setHours(0, 0, 0, 0);
+  const dayEnd = new Date(dayStart);
+  dayEnd.setDate(dayEnd.getDate() + 1);
+
+  const [summary, profile, foodLogs] = await Promise.all([
+    prisma.dailySummary.findUnique({ where: { date: dayStart } }),
+    prisma.userProfile.findFirst(),
+    prisma.foodLog.findMany({
+      where: { date: { gte: dayStart, lt: dayEnd } },
+      select: { estimatedKcal: true },
+    }),
+  ]);
+
+  if (!summary) return; // Garmin 싱크 전이면 skip
+
+  const target = profile?.targetCalories ?? null;
+  const active = summary.activeCalories ?? null;
+
+  const availableCalories =
+    target !== null && active !== null ? target + active : null;
+
+  const hasFoodLogs = foodLogs.length > 0;
+  const estimatedIntakeCalories = hasFoodLogs
+    ? foodLogs.reduce((sum, f) => sum + (f.estimatedKcal ?? 0), 0)
+    : null;
+
+  const calorieBalance =
+    estimatedIntakeCalories !== null && availableCalories !== null
+      ? estimatedIntakeCalories - availableCalories
+      : null;
+
+  await prisma.dailySummary.update({
+    where: { id: summary.id },
+    data: {
+      availableCalories,
+      estimatedIntakeCalories,
+      calorieBalance,
+    },
+  });
+}

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -3,21 +3,29 @@ import prisma from "@/lib/prisma";
 
 /**
  * 주어진 reference Date에서 KST 기준 일(day)의 [시작, 끝) UTC 경계를 산출.
+ * 서버 타임존과 독립적으로 동작하도록 Intl.DateTimeFormat + Date.UTC를 사용.
  * DailySummary.date 및 FoodLog.date 집계 기준으로 사용.
  */
 function kstDayBoundary(referenceDate: Date): {
   kstDayStart: Date;
   kstDayEnd: Date;
 } {
-  // Asia/Seoul 벽시계(wall-clock) 기준 yyyy-mm-dd
-  const seoulStr = referenceDate.toLocaleString("en-US", {
+  // Asia/Seoul 벽시계 기준 연/월/일 추출 (서버 TZ 무관)
+  const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone: "Asia/Seoul",
-  });
-  const seoul = new Date(seoulStr);
-  seoul.setHours(0, 0, 0, 0);
-  const kstDayStart = seoul;
-  const kstDayEnd = new Date(kstDayStart);
-  kstDayEnd.setDate(kstDayEnd.getDate() + 1);
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(referenceDate);
+  const y = Number(parts.find((p) => p.type === "year")!.value);
+  const m = Number(parts.find((p) => p.type === "month")!.value);
+  const d = Number(parts.find((p) => p.type === "day")!.value);
+
+  // KST(=UTC+9) 00:00의 UTC 타임스탬프
+  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+  const kstDayStartMs = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
+  const kstDayStart = new Date(kstDayStartMs);
+  const kstDayEnd = new Date(kstDayStartMs + 24 * 60 * 60 * 1000);
   return { kstDayStart, kstDayEnd };
 }
 
@@ -87,4 +95,36 @@ async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
       calorieBalance,
     },
   });
+}
+
+/**
+ * 모든 DailySummary의 칼로리 밸런스를 재계산.
+ * UserProfile.targetCalories 변경 등 전역 파라미터가 바뀌었을 때 호출.
+ * 각 날짜별로 독립 트랜잭션으로 실행하여 부분 실패 시 전체 중단되지 않음.
+ */
+export async function recalculateAllCalorieBalances(): Promise<{
+  processed: number;
+  failed: number;
+}> {
+  const summaries = await prisma.dailySummary.findMany({
+    select: { date: true },
+    orderBy: { date: "desc" },
+  });
+
+  let processed = 0;
+  let failed = 0;
+  for (const s of summaries) {
+    try {
+      await recalculateCalorieBalance(s.date);
+      processed++;
+    } catch (err) {
+      failed++;
+      console.error(
+        "[calorie-balance] 재계산 실패",
+        s.date.toISOString(),
+        err instanceof Error ? err.message : String(err)
+      );
+    }
+  }
+  return { processed, failed };
 }

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -1,5 +1,9 @@
-import type { Prisma } from "@/generated/prisma/client";
-import prisma from "@/lib/prisma";
+import type { Prisma, PrismaClient } from "@/generated/prisma/client";
+import defaultPrisma from "@/lib/prisma";
+
+/** Serializable 트랜잭션 재시도 상수 */
+const MAX_RETRY = 3;
+const RETRY_DELAY_MS = 50;
 
 /**
  * reference Date에서 다음 3가지 시각값을 산출:
@@ -49,20 +53,45 @@ type TxClient = Prisma.TransactionClient;
  *
  * 동시성 보호:
  *   - Serializable 트랜잭션으로 aggregate-then-update 간 race(lost update) 차단.
+ *   - 직렬화 충돌(P2034) 시 자동 재시도 (최대 MAX_RETRY 회).
  *   - 호출자가 이미 트랜잭션에 있으면 `tx`로 동일 트랜잭션 내 실행.
+ *
+ * @param client — 사용할 PrismaClient. 봇 등 별도 client가 있는 프로세스에서 전달.
  */
 export async function recalculateCalorieBalance(
   referenceDate: Date,
-  tx?: TxClient
+  tx?: TxClient,
+  client?: PrismaClient
 ): Promise<void> {
   if (tx) {
     await doRecalc(referenceDate, tx);
     return;
   }
-  await prisma.$transaction(
-    async (innerTx) => doRecalc(referenceDate, innerTx),
-    { isolationLevel: "Serializable" }
+  const db = client ?? defaultPrisma;
+  await withSerializableRetry(db, (innerTx) =>
+    doRecalc(referenceDate, innerTx)
   );
+}
+
+/** Serializable 트랜잭션 + 직렬화 충돌(P2034) 자동 재시도 */
+async function withSerializableRetry(
+  db: PrismaClient,
+  fn: (tx: TxClient) => Promise<void>
+): Promise<void> {
+  for (let attempt = 1; attempt <= MAX_RETRY; attempt++) {
+    try {
+      await (db as unknown as typeof defaultPrisma).$transaction(
+        async (tx) => fn(tx),
+        { isolationLevel: "Serializable" }
+      );
+      return;
+    } catch (err) {
+      const isSerializationFailure =
+        err instanceof Error && err.message.includes("P2034");
+      if (!isSerializationFailure || attempt === MAX_RETRY) throw err;
+      await new Promise((r) => setTimeout(r, RETRY_DELAY_MS * attempt));
+    }
+  }
 }
 
 async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
@@ -115,11 +144,14 @@ async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
  * UserProfile.targetCalories 변경 등 전역 파라미터가 바뀌었을 때 호출.
  * 각 날짜별로 독립 트랜잭션으로 실행하여 부분 실패 시 전체 중단되지 않음.
  */
-export async function recalculateAllCalorieBalances(): Promise<{
+export async function recalculateAllCalorieBalances(
+  client?: PrismaClient
+): Promise<{
   processed: number;
   failed: number;
 }> {
-  const summaries = await prisma.dailySummary.findMany({
+  const db = client ?? defaultPrisma;
+  const summaries = await db.dailySummary.findMany({
     select: { date: true },
     orderBy: { date: "desc" },
   });
@@ -128,7 +160,7 @@ export async function recalculateAllCalorieBalances(): Promise<{
   let failed = 0;
   for (const s of summaries) {
     try {
-      await recalculateCalorieBalance(s.date);
+      await recalculateCalorieBalance(s.date, undefined, db);
       processed++;
     } catch (err) {
       failed++;

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -2,15 +2,17 @@ import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 
 /**
- * 주어진 reference Date에서 KST 기준 일(day)의 [시작, 끝) UTC 경계를 산출.
- * 서버 타임존과 독립적으로 동작하도록 Intl.DateTimeFormat + Date.UTC를 사용.
- * DailySummary.date 및 FoodLog.date 집계 기준으로 사용.
+ * reference Date에서 "KST 벽시계 기준 해당 날짜"의 [시작, 끝) 경계를 산출.
+ *
+ * - KST 날짜(Y-M-D)는 Intl.DateTimeFormat으로 서버 TZ와 무관하게 추출.
+ * - 경계 Date 객체는 "서버 로컬 타임존의 해당 날짜 midnight"으로 구성하여
+ *   DailySummary.date(= `startOfDay(date)`, 서버 로컬 midnight) 저장 관례와 일치.
+ *   (코드베이스 전반이 server TZ = KST를 가정. 서버가 KST면 KST midnight UTC instant와 동일.)
  */
 function kstDayBoundary(referenceDate: Date): {
   kstDayStart: Date;
   kstDayEnd: Date;
 } {
-  // Asia/Seoul 벽시계 기준 연/월/일 추출 (서버 TZ 무관)
   const parts = new Intl.DateTimeFormat("en-CA", {
     timeZone: "Asia/Seoul",
     year: "numeric",
@@ -21,11 +23,8 @@ function kstDayBoundary(referenceDate: Date): {
   const m = Number(parts.find((p) => p.type === "month")!.value);
   const d = Number(parts.find((p) => p.type === "day")!.value);
 
-  // KST(=UTC+9) 00:00의 UTC 타임스탬프
-  const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
-  const kstDayStartMs = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
-  const kstDayStart = new Date(kstDayStartMs);
-  const kstDayEnd = new Date(kstDayStartMs + 24 * 60 * 60 * 1000);
+  const kstDayStart = new Date(y, m - 1, d, 0, 0, 0, 0);
+  const kstDayEnd = new Date(y, m - 1, d + 1, 0, 0, 0, 0);
   return { kstDayStart, kstDayEnd };
 }
 
@@ -63,8 +62,12 @@ async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
   const [summary, profile, intakeAgg] = await Promise.all([
     tx.dailySummary.findUnique({ where: { date: kstDayStart } }),
     tx.userProfile.findFirst(),
+    // estimatedKcal이 있는 로그만 집계. null인 로그(예: 봇 미추정)는 섭취 계산에서 제외.
     tx.foodLog.aggregate({
-      where: { date: { gte: kstDayStart, lt: kstDayEnd } },
+      where: {
+        date: { gte: kstDayStart, lt: kstDayEnd },
+        estimatedKcal: { not: null },
+      },
       _sum: { estimatedKcal: true },
       _count: { _all: true },
     }),
@@ -77,8 +80,9 @@ async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
   const availableCalories =
     target !== null && active !== null ? target + active : null;
 
-  const hasFoodLogs = intakeAgg._count._all > 0;
-  const estimatedIntakeCalories = hasFoodLogs
+  // kcal이 집계된 로그가 하나도 없으면 intake = null (0 kcal로 표시하지 않음)
+  const hasCountedLogs = intakeAgg._count._all > 0;
+  const estimatedIntakeCalories = hasCountedLogs
     ? (intakeAgg._sum.estimatedKcal ?? 0)
     : null;
 

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -1,30 +1,64 @@
+import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
+
+/**
+ * 주어진 reference Date에서 KST 기준 일(day)의 [시작, 끝) UTC 경계를 산출.
+ * DailySummary.date 및 FoodLog.date 집계 기준으로 사용.
+ */
+function kstDayBoundary(referenceDate: Date): {
+  kstDayStart: Date;
+  kstDayEnd: Date;
+} {
+  // Asia/Seoul 벽시계(wall-clock) 기준 yyyy-mm-dd
+  const seoulStr = referenceDate.toLocaleString("en-US", {
+    timeZone: "Asia/Seoul",
+  });
+  const seoul = new Date(seoulStr);
+  seoul.setHours(0, 0, 0, 0);
+  const kstDayStart = seoul;
+  const kstDayEnd = new Date(kstDayStart);
+  kstDayEnd.setDate(kstDayEnd.getDate() + 1);
+  return { kstDayStart, kstDayEnd };
+}
+
+type TxClient = Prisma.TransactionClient;
 
 /**
  * 특정 날짜의 칼로리 밸런스를 재계산하여 DailySummary에 저장.
  *
  * 계산식:
  *   availableCalories = targetCalories(프로필) + activeCalories(Garmin)
- *   estimatedIntakeCalories = SUM(FoodLog.estimatedKcal) for the day
+ *   estimatedIntakeCalories = SUM(FoodLog.estimatedKcal) for the KST day
  *   calorieBalance = intake - available  (음수 = 결손/감량, 양수 = 잉여)
  *
- * 프로필/활성 칼로리/섭취 기록 중 하나라도 없으면 해당 값만 null로 저장.
+ * 동시성 보호:
+ *   - Serializable 트랜잭션으로 aggregate-then-update 간 race(lost update) 차단.
+ *   - 호출자가 이미 트랜잭션에 있으면 `tx`로 동일 트랜잭션 내 실행.
  */
 export async function recalculateCalorieBalance(
-  date: Date
+  referenceDate: Date,
+  tx?: TxClient
 ): Promise<void> {
-  // 해당 날짜의 midnight 기준 (DailySummary.date는 midnight)
-  const dayStart = new Date(date);
-  dayStart.setHours(0, 0, 0, 0);
-  const dayEnd = new Date(dayStart);
-  dayEnd.setDate(dayEnd.getDate() + 1);
+  if (tx) {
+    await doRecalc(referenceDate, tx);
+    return;
+  }
+  await prisma.$transaction(
+    async (innerTx) => doRecalc(referenceDate, innerTx),
+    { isolationLevel: "Serializable" }
+  );
+}
 
-  const [summary, profile, foodLogs] = await Promise.all([
-    prisma.dailySummary.findUnique({ where: { date: dayStart } }),
-    prisma.userProfile.findFirst(),
-    prisma.foodLog.findMany({
-      where: { date: { gte: dayStart, lt: dayEnd } },
-      select: { estimatedKcal: true },
+async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
+  const { kstDayStart, kstDayEnd } = kstDayBoundary(referenceDate);
+
+  const [summary, profile, intakeAgg] = await Promise.all([
+    tx.dailySummary.findUnique({ where: { date: kstDayStart } }),
+    tx.userProfile.findFirst(),
+    tx.foodLog.aggregate({
+      where: { date: { gte: kstDayStart, lt: kstDayEnd } },
+      _sum: { estimatedKcal: true },
+      _count: { _all: true },
     }),
   ]);
 
@@ -32,13 +66,12 @@ export async function recalculateCalorieBalance(
 
   const target = profile?.targetCalories ?? null;
   const active = summary.activeCalories ?? null;
-
   const availableCalories =
     target !== null && active !== null ? target + active : null;
 
-  const hasFoodLogs = foodLogs.length > 0;
+  const hasFoodLogs = intakeAgg._count._all > 0;
   const estimatedIntakeCalories = hasFoodLogs
-    ? foodLogs.reduce((sum, f) => sum + (f.estimatedKcal ?? 0), 0)
+    ? (intakeAgg._sum.estimatedKcal ?? 0)
     : null;
 
   const calorieBalance =
@@ -46,7 +79,7 @@ export async function recalculateCalorieBalance(
       ? estimatedIntakeCalories - availableCalories
       : null;
 
-  await prisma.dailySummary.update({
+  await tx.dailySummary.update({
     where: { id: summary.id },
     data: {
       availableCalories,

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -2,13 +2,16 @@ import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 
 /**
- * reference Date에서 "KST 벽시계 기준 해당 날짜"의 [시작, 끝) 경계를 산출.
+ * reference Date에서 "KST 벽시계 기준 해당 날짜"의 [시작, 끝) UTC instant를 산출.
  *
  * - KST 날짜(Y-M-D)는 Intl.DateTimeFormat으로 서버 TZ와 무관하게 추출.
- * - 경계 Date 객체는 "서버 로컬 타임존의 해당 날짜 midnight"으로 구성하여
- *   DailySummary.date(= `startOfDay(date)`, 서버 로컬 midnight) 저장 관례와 일치.
- *   (코드베이스 전반이 server TZ = KST를 가정. 서버가 KST면 KST midnight UTC instant와 동일.)
+ * - 경계는 진짜 KST 00:00의 UTC instant(= Date.UTC(Y,M,D) - 9h)로 구성.
+ *   → FoodLog.date(실제 UTC instant 저장)의 집계가 서버 TZ와 무관하게 정확.
+ *   → DailySummary.date는 코드베이스 관례(server TZ = KST)에서 KST midnight UTC instant와
+ *     동일하므로 lookup도 일치.
  */
+const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
 function kstDayBoundary(referenceDate: Date): {
   kstDayStart: Date;
   kstDayEnd: Date;
@@ -23,8 +26,9 @@ function kstDayBoundary(referenceDate: Date): {
   const m = Number(parts.find((p) => p.type === "month")!.value);
   const d = Number(parts.find((p) => p.type === "day")!.value);
 
-  const kstDayStart = new Date(y, m - 1, d, 0, 0, 0, 0);
-  const kstDayEnd = new Date(y, m - 1, d + 1, 0, 0, 0, 0);
+  const kstMidnightUTCms = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
+  const kstDayStart = new Date(kstMidnightUTCms);
+  const kstDayEnd = new Date(kstMidnightUTCms + 24 * 60 * 60 * 1000);
   return { kstDayStart, kstDayEnd };
 }
 

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -2,17 +2,17 @@ import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 
 /**
- * reference Date에서 "KST 벽시계 기준 해당 날짜"의 [시작, 끝) UTC instant를 산출.
+ * reference Date에서 다음 3가지 시각값을 산출:
  *
- * - KST 날짜(Y-M-D)는 Intl.DateTimeFormat으로 서버 TZ와 무관하게 추출.
- * - 경계는 진짜 KST 00:00의 UTC instant(= Date.UTC(Y,M,D) - 9h)로 구성.
- *   → FoodLog.date(실제 UTC instant 저장)의 집계가 서버 TZ와 무관하게 정확.
- *   → DailySummary.date는 코드베이스 관례(server TZ = KST)에서 KST midnight UTC instant와
- *     동일하므로 lookup도 일치.
+ * 1. `summaryKey` — DailySummary 조회용 key. sync 파이프라인의 저장 관례와 정합.
+ *    `startOfDay(date)` = 서버 로컬 midnight of (KST wall-clock 날짜). 서버 TZ에 의존.
+ * 2. `kstDayStart` / `kstDayEnd` — FoodLog.date(실제 UTC instant) 집계용 경계.
+ *    진짜 KST 00:00 UTC instant(= Date.UTC(Y,M,D) - 9h)로 서버 TZ와 무관하게 정확.
  */
 const KST_OFFSET_MS = 9 * 60 * 60 * 1000;
 
 function kstDayBoundary(referenceDate: Date): {
+  summaryKey: Date;
   kstDayStart: Date;
   kstDayEnd: Date;
 } {
@@ -26,10 +26,15 @@ function kstDayBoundary(referenceDate: Date): {
   const m = Number(parts.find((p) => p.type === "month")!.value);
   const d = Number(parts.find((p) => p.type === "day")!.value);
 
+  // DailySummary.date 저장 관례: 서버 로컬 midnight of KST 날짜
+  const summaryKey = new Date(y, m - 1, d, 0, 0, 0, 0);
+
+  // FoodLog 집계 경계: 진짜 KST 00:00 UTC instant
   const kstMidnightUTCms = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
   const kstDayStart = new Date(kstMidnightUTCms);
   const kstDayEnd = new Date(kstMidnightUTCms + 24 * 60 * 60 * 1000);
-  return { kstDayStart, kstDayEnd };
+
+  return { summaryKey, kstDayStart, kstDayEnd };
 }
 
 type TxClient = Prisma.TransactionClient;
@@ -61,10 +66,10 @@ export async function recalculateCalorieBalance(
 }
 
 async function doRecalc(referenceDate: Date, tx: TxClient): Promise<void> {
-  const { kstDayStart, kstDayEnd } = kstDayBoundary(referenceDate);
+  const { summaryKey, kstDayStart, kstDayEnd } = kstDayBoundary(referenceDate);
 
   const [summary, profile, intakeAgg] = await Promise.all([
-    tx.dailySummary.findUnique({ where: { date: kstDayStart } }),
+    tx.dailySummary.findUnique({ where: { date: summaryKey } }),
     tx.userProfile.findFirst(),
     // estimatedKcal이 있는 로그만 집계. null인 로그(예: 봇 미추정)는 섭취 계산에서 제외.
     tx.foodLog.aggregate({

--- a/src/lib/garmin/fetchers/daily-summary.ts
+++ b/src/lib/garmin/fetchers/daily-summary.ts
@@ -66,8 +66,16 @@ export async function syncDailySummaries(
         create: { date: dayDate, ...data },
       });
 
-      // M4-2: 칼로리 밸런스 재계산 (targetCalories + activeCalories, 섭취와 비교)
-      await recalculateCalorieBalance(dayDate);
+      // M4-2: 칼로리 밸런스 재계산 (targetCalories + activeCalories, 섭취와 비교).
+      // 재계산 실패는 싱크 전체를 실패시키지 않음 (다음 싱크에서 자연 복구).
+      try {
+        await recalculateCalorieBalance(dayDate);
+      } catch (err) {
+        console.error(
+          `[daily-summary] 칼로리 밸런스 재계산 실패 (${formatDate(dayDate)}):`,
+          err instanceof Error ? err.message : String(err)
+        );
+      }
 
       synced++;
     } catch (error) {

--- a/src/lib/garmin/fetchers/daily-summary.ts
+++ b/src/lib/garmin/fetchers/daily-summary.ts
@@ -1,6 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
+import { recalculateCalorieBalance } from "@/lib/fitness/calorie-balance";
 import { dateRange, formatDate, startOfDay, todayKSTString, withRateLimit } from "../utils";
 
 const DAILY_SUMMARY_URL =
@@ -64,6 +65,9 @@ export async function syncDailySummaries(
         update: data,
         create: { date: dayDate, ...data },
       });
+
+      // M4-2: 칼로리 밸런스 재계산 (targetCalories + activeCalories, 섭취와 비교)
+      await recalculateCalorieBalance(dayDate);
 
       synced++;
     } catch (error) {


### PR DESCRIPTION
## 변경 사항

DailySummary에 일일 칼로리 밸런스(섭취 vs 섭취가능)를 저장하고, 싱크/식단 입력 시 자동 재계산되도록 구현. 대시보드에 밸런스 카드 노출.

### 계산식
```
availableCalories = UserProfile.targetCalories + DailySummary.activeCalories
estimatedIntakeCalories = SUM(FoodLog.estimatedKcal) for KST day
calorieBalance = intake - available  (음수 = 결손/감량)
```

### 추가
- `DailySummary.estimatedIntakeCalories / availableCalories / calorieBalance`
- `src/lib/fitness/calorie-balance.ts` — `recalculateCalorieBalance`, `recalculateAllCalorieBalances`
- 자동 재계산 훅: daily-summary 싱크 후, /api/food POST 후, 봇 food 입력 후, 프로필 targetCalories 변경 시
- 대시보드 칼로리 밸런스 카드 (결손=초록, 과다결손=노랑, 잉여=빨강)
- 마이그레이션 `add_calorie_balance`

Closes #55

## 체크리스트
- [x] lint / tsc / build 통과
- [x] codex-cli 리뷰 4 라운드 → P0/P1/P2 = 0/0/0

## 코드 리뷰 요약
- 라운드 1: P1 4건 (KST 경계, 동시성, 원자화, aggregate 최적화) → 수정
- 라운드 2: P1 1건 (TZ robust) + P2 2건 (프로필 stale, 봇 미재계산) → 수정
- 라운드 3: P1 1건 (저장 관례 정합) + P2 1건 (null kcal 집계) → 수정
- 라운드 4: **전부 0건 ✅**

## 테스트 플랜
- [ ] /settings/profile에서 targetCalories 1890 저장 → 기존 DailySummary에 availableCalories 생성 확인
- [ ] /api/food POST 후 대시보드 칼로리 밸런스 카드 갱신
- [ ] Garmin 싱크 후 activeCalories와 함께 balance 갱신
- [ ] 봇에서 "점심 김치찌개" 입력 (null kcal) → intake가 0으로 표시되지 않고 null 유지