### PR TITLE
[M4-5] 운동 강도 자동 분류 (#61)

### DIFF
--- a/prisma/migrations/20260416142715_add_intensity_fields/migration.sql
+++ b/prisma/migrations/20260416142715_add_intensity_fields/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable: M4-5 운동 강도 자동 분류 필드
+ALTER TABLE "Activity"
+  ADD COLUMN "zoneDistribution" JSONB,
+  ADD COLUMN "estimatedZone" INTEGER,
+  ADD COLUMN "intensityScore" DOUBLE PRECISION,
+  ADD COLUMN "intensityLabel" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -62,6 +62,11 @@ model Activity {
   avgRespirationRate Float?           // breaths/min
   lapCount        Int?
   splitSummaries  Json?               // km별 스플릿 데이터
+  // M4-5: 강도 자동 분류
+  zoneDistribution Json?              // {z1, z2, z3, z4, z5} 초 단위 (Garmin hrTimeInZone_1~5)
+  estimatedZone   Int?                // 대표 Zone (1~5, 가중 평균)
+  intensityScore  Float?              // 강도 점수 (0~100, TRIMP 유사)
+  intensityLabel  String?             // recovery|easy|tempo|threshold|interval|max
   rawData         Json?
   createdAt       DateTime @default(now())
 

--- a/scripts/backfill-intensity.ts
+++ b/scripts/backfill-intensity.ts
@@ -6,25 +6,43 @@
 import "dotenv/config";
 import prisma from "../src/lib/prisma";
 import { computeIntensityFromRawData } from "../src/lib/fitness/intensity";
-import { resolveLTHR } from "../src/lib/fitness/zones";
 
+/**
+ * 옵션:
+ *   --force: 이미 분류된 활동도 재분류 (기본: 이미 값 있으면 skip)
+ */
 async function main() {
+  const force = process.argv.includes("--force");
   const profile = await prisma.userProfile.findFirst();
-  const lthr = profile ? resolveLTHR(profile) : null;
-  console.log(`LTHR: ${lthr ?? "없음 (분포 기반 분류만 사용)"}`);
+  const lthr = profile?.lthr ?? null;
+  console.log(
+    `LTHR(실측): ${lthr ?? "없음 (분포 기반 분류만 사용)"} | force=${force}`
+  );
 
   const activities = await prisma.activity.findMany({
-    select: { id: true, garminId: true, avgHR: true, rawData: true, name: true },
+    select: {
+      id: true,
+      garminId: true,
+      avgHR: true,
+      rawData: true,
+      name: true,
+      intensityLabel: true,
+    },
     orderBy: { startTime: "desc" },
   });
 
   console.log(`총 ${activities.length}개 활동 처리 시작...\n`);
 
-  let processed = 0;
   let withData = 0;
   let skipped = 0;
+  let alreadyClassified = 0;
 
   for (const a of activities) {
+    if (!force && a.intensityLabel !== null) {
+      alreadyClassified++;
+      continue;
+    }
+
     const intensity = computeIntensityFromRawData({
       rawData: a.rawData as Record<string, unknown> | null,
       avgHR: a.avgHR,
@@ -45,7 +63,6 @@ async function main() {
         intensityLabel: intensity.intensityLabel,
       },
     });
-    processed++;
     withData++;
 
     console.log(
@@ -55,7 +72,8 @@ async function main() {
   }
 
   console.log(
-    `\n완료: 총 ${activities.length}개 중 ${withData}개 분류, ${skipped}개 skip(분포 데이터 없음)`
+    `\n완료: 총 ${activities.length}개 중 ${withData}개 분류, ` +
+      `${alreadyClassified}개 기존 분류(skip), ${skipped}개 skip(분포 데이터 없음)`
   );
 }
 

--- a/scripts/backfill-intensity.ts
+++ b/scripts/backfill-intensity.ts
@@ -1,0 +1,69 @@
+/**
+ * M4-5: 기존 Activity에 대해 intensity 필드 backfill.
+ *
+ * 실행: npx tsx scripts/backfill-intensity.ts
+ */
+import "dotenv/config";
+import prisma from "../src/lib/prisma";
+import { computeIntensityFromRawData } from "../src/lib/fitness/intensity";
+import { resolveLTHR } from "../src/lib/fitness/zones";
+
+async function main() {
+  const profile = await prisma.userProfile.findFirst();
+  const lthr = profile ? resolveLTHR(profile) : null;
+  console.log(`LTHR: ${lthr ?? "없음 (분포 기반 분류만 사용)"}`);
+
+  const activities = await prisma.activity.findMany({
+    select: { id: true, garminId: true, avgHR: true, rawData: true, name: true },
+    orderBy: { startTime: "desc" },
+  });
+
+  console.log(`총 ${activities.length}개 활동 처리 시작...\n`);
+
+  let processed = 0;
+  let withData = 0;
+  let skipped = 0;
+
+  for (const a of activities) {
+    const intensity = computeIntensityFromRawData({
+      rawData: a.rawData as Record<string, unknown> | null,
+      avgHR: a.avgHR,
+      lthr,
+    });
+
+    if (!intensity) {
+      skipped++;
+      continue;
+    }
+
+    await prisma.activity.update({
+      where: { id: a.id },
+      data: {
+        zoneDistribution: intensity.zoneDistribution as unknown as object,
+        estimatedZone: intensity.estimatedZone,
+        intensityScore: intensity.intensityScore,
+        intensityLabel: intensity.intensityLabel,
+      },
+    });
+    processed++;
+    withData++;
+
+    console.log(
+      `  ✅ ${a.name} (${a.garminId}) → Zone ${intensity.estimatedZone}, ` +
+        `${intensity.intensityLabel}, score ${intensity.intensityScore}`
+    );
+  }
+
+  console.log(
+    `\n완료: 총 ${activities.length}개 중 ${withData}개 분류, ${skipped}개 skip(분포 데이터 없음)`
+  );
+}
+
+main()
+  .catch((err) => {
+    console.error("Fatal:", err);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await prisma.$disconnect();
+  });

--- a/src/app/activities/[id]/activity-detail-client.tsx
+++ b/src/app/activities/[id]/activity-detail-client.tsx
@@ -29,6 +29,11 @@ interface ActivityData {
   anaerobicTE: number | null;
   avgRespirationRate: number | null;
   lapCount: number | null;
+  // M4-5: 강도 자동 분류
+  zoneDistribution: { z1: number; z2: number; z3: number; z4: number; z5: number } | null;
+  estimatedZone: number | null;
+  intensityScore: number | null;
+  intensityLabel: string | null;
 }
 
 interface Props {
@@ -80,9 +85,21 @@ export default function ActivityDetailClient({ activity }: Props) {
     }
   }
 
+  const hasIntensity = activity.zoneDistribution !== null && activity.intensityLabel !== null;
+
   return (
     <div>
       <ActivityDetail {...activity} />
+
+      {/* M4-5: 강도 분류 + HR Zone 분포 */}
+      {hasIntensity && activity.zoneDistribution && (
+        <IntensityBreakdown
+          dist={activity.zoneDistribution}
+          label={activity.intensityLabel!}
+          score={activity.intensityScore}
+          zone={activity.estimatedZone}
+        />
+      )}
 
       {/* 러닝 다이나믹스 */}
       {hasDynamics && (
@@ -156,6 +173,120 @@ export default function ActivityDetailClient({ activity }: Props) {
             {aiLoading ? "분석 중..." : "🤖 AI 평가 요청"}
           </button>
         )}
+      </div>
+    </div>
+  );
+}
+
+const ZONE_META = [
+  { zone: 1, name: "회복", color: "#a3a3a3" },
+  { zone: 2, name: "이지", color: "#22c55e" },
+  { zone: 3, name: "에어로빅", color: "#60a5fa" },
+  { zone: 4, name: "역치", color: "#f59e0b" },
+  { zone: 5, name: "VO2max", color: "#ef4444" },
+];
+
+const LABEL_META: Record<string, { text: string; badge: string }> = {
+  recovery: { text: "회복 런", badge: "bg-slate-700 text-slate-200" },
+  easy: { text: "이지 런", badge: "bg-green-900/40 text-green-300" },
+  tempo: { text: "템포 런", badge: "bg-blue-900/40 text-blue-300" },
+  threshold: { text: "한계치 런", badge: "bg-amber-900/40 text-amber-300" },
+  interval: { text: "인터벌", badge: "bg-red-900/40 text-red-300" },
+  max: { text: "최대 강도", badge: "bg-red-900/60 text-red-200" },
+};
+
+function IntensityBreakdown({
+  dist,
+  label,
+  score,
+  zone,
+}: {
+  dist: { z1: number; z2: number; z3: number; z4: number; z5: number };
+  label: string;
+  score: number | null;
+  zone: number | null;
+}) {
+  const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
+  const values = [dist.z1, dist.z2, dist.z3, dist.z4, dist.z5];
+  const labelMeta = LABEL_META[label] ?? {
+    text: label,
+    badge: "bg-slate-700 text-slate-200",
+  };
+
+  function fmt(sec: number): string {
+    const m = Math.floor(sec / 60);
+    const s = Math.round(sec % 60);
+    return `${m}:${String(s).padStart(2, "0")}`;
+  }
+
+  return (
+    <div className="mt-6">
+      <div className="flex items-center justify-between mb-3">
+        <h2 className="text-lg font-semibold">강도 분석</h2>
+        <div className="flex items-center gap-2">
+          <span
+            className={`text-[11px] font-medium px-2 py-0.5 rounded ${labelMeta.badge}`}
+          >
+            {labelMeta.text}
+          </span>
+          {zone !== null && (
+            <span className="text-[11px] text-dim">Zone {zone}</span>
+          )}
+          {score !== null && (
+            <span className="text-[11px] text-dim">
+              {score.toFixed(0)}점
+            </span>
+          )}
+        </div>
+      </div>
+
+      <div className="bg-card border border-border rounded-xl p-5">
+        <div className="text-[11px] text-dim tracking-wider uppercase mb-3">
+          HR Zone 분포
+        </div>
+
+        {/* 스택드 바 */}
+        <div className="h-4 rounded bg-surface overflow-hidden flex mb-4">
+          {ZONE_META.map((z, i) => {
+            const pct = total > 0 ? (values[i] / total) * 100 : 0;
+            if (pct <= 0) return null;
+            return (
+              <div
+                key={z.zone}
+                style={{
+                  width: `${pct}%`,
+                  backgroundColor: z.color,
+                }}
+                title={`Z${z.zone} ${z.name}: ${pct.toFixed(1)}%`}
+              />
+            );
+          })}
+        </div>
+
+        {/* 상세 리스트 */}
+        <div className="grid grid-cols-5 gap-2 text-center text-[11px]">
+          {ZONE_META.map((z, i) => {
+            const sec = values[i];
+            const pct = total > 0 ? (sec / total) * 100 : 0;
+            return (
+              <div key={z.zone}>
+                <div
+                  className="font-medium mb-0.5"
+                  style={{ color: z.color }}
+                >
+                  Z{z.zone}
+                </div>
+                <div className="text-dim text-[10px]">{z.name}</div>
+                <div className="font-[family-name:var(--font-geist-mono)] text-sub mt-1">
+                  {fmt(sec)}
+                </div>
+                <div className="text-dim text-[10px]">
+                  {pct.toFixed(0)}%
+                </div>
+              </div>
+            );
+          })}
+        </div>
       </div>
     </div>
   );

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import prisma from "@/lib/prisma";
+import { parseZoneDistribution } from "@/lib/fitness/intensity";
 import ActivityDetailClient from "./activity-detail-client";
 import Link from "next/link";
 
@@ -65,10 +66,7 @@ export default async function ActivityDetailPage({ params }: PageProps) {
           id,
           ...activity,
           startTime: activity.startTime.toISOString(),
-          zoneDistribution:
-            activity.zoneDistribution as
-              | { z1: number; z2: number; z3: number; z4: number; z5: number }
-              | null,
+          zoneDistribution: parseZoneDistribution(activity.zoneDistribution),
         }}
       />
     </div>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -36,6 +36,11 @@ export default async function ActivityDetailPage({ params }: PageProps) {
       anaerobicTE: true,
       avgRespirationRate: true,
       lapCount: true,
+      // M4-5: 강도 자동 분류
+      zoneDistribution: true,
+      estimatedZone: true,
+      intensityScore: true,
+      intensityLabel: true,
     },
   });
 
@@ -60,6 +65,10 @@ export default async function ActivityDetailPage({ params }: PageProps) {
           id,
           ...activity,
           startTime: activity.startTime.toISOString(),
+          zoneDistribution:
+            activity.zoneDistribution as
+              | { z1: number; z2: number; z3: number; z4: number; z5: number }
+              | null,
         }}
       />
     </div>

--- a/src/lib/fitness/intensity.ts
+++ b/src/lib/fitness/intensity.ts
@@ -45,12 +45,12 @@ function toNum(v: unknown): number {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
-/** 분포 기반 분류가 의미 있는 최소 zone 시간(초). 이하면 null 처리. */
+/** 분포 기반 분류에 필요한 최소 zone 시간(초). 이하면 null 처리(경계값 포함). */
 export const MIN_ZONE_TOTAL_SEC = 60;
 
 /**
  * Garmin rawData에서 HR Zone 시간 분포를 추출.
- * 모든 zone이 0이거나 총합이 MIN_ZONE_TOTAL_SEC 미만이면 null 반환.
+ * 모든 zone이 0이거나 총합이 MIN_ZONE_TOTAL_SEC 이하이면 null 반환.
  */
 export function extractZoneDistribution(
   rawData: Record<string, unknown> | null | undefined
@@ -64,7 +64,7 @@ export function extractZoneDistribution(
     z5: toNum(rawData.hrTimeInZone_5),
   };
   const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
-  if (total < MIN_ZONE_TOTAL_SEC) return null;
+  if (total <= MIN_ZONE_TOTAL_SEC) return null;
   return dist;
 }
 

--- a/src/lib/fitness/intensity.ts
+++ b/src/lib/fitness/intensity.ts
@@ -1,0 +1,160 @@
+/**
+ * 운동 강도 자동 분류 (M4-5).
+ *
+ * 데이터 소스:
+ *   Garmin이 Activity.rawData에 제공하는 hrTimeInZone_1~5 (초 단위).
+ *   Garmin 기본 Zone은 %maxHR 기반이지만 사용자가 Garmin Connect에서 LTHR 기반으로
+ *   설정해두면 그 값이 그대로 사용됨.
+ *
+ * 출력:
+ *   - zoneDistribution: {z1..z5} 초 단위 (raw)
+ *   - estimatedZone: 1~5 (가중 평균 Zone)
+ *   - intensityScore: 0~100 (TRIMP 유사)
+ *   - intensityLabel: recovery|easy|tempo|threshold|interval|max
+ */
+
+import { calculateHRZone } from "./zones";
+
+export type HRZone = 1 | 2 | 3 | 4 | 5;
+export type IntensityLabel =
+  | "recovery"
+  | "easy"
+  | "tempo"
+  | "threshold"
+  | "interval"
+  | "max";
+
+export interface ZoneDistribution {
+  z1: number; // seconds
+  z2: number;
+  z3: number;
+  z4: number;
+  z5: number;
+}
+
+export interface IntensityClassification {
+  zoneDistribution: ZoneDistribution;
+  estimatedZone: HRZone;
+  intensityScore: number;
+  intensityLabel: IntensityLabel;
+}
+
+function toNum(v: unknown): number {
+  if (v === null || v === undefined) return 0;
+  const n = Number(v);
+  return Number.isFinite(n) && n > 0 ? n : 0;
+}
+
+/**
+ * Garmin rawData에서 HR Zone 시간 분포를 추출.
+ * 모든 zone이 0이면 null 반환 (분포 데이터 없음).
+ */
+export function extractZoneDistribution(
+  rawData: Record<string, unknown> | null | undefined
+): ZoneDistribution | null {
+  if (!rawData) return null;
+  const dist: ZoneDistribution = {
+    z1: toNum(rawData.hrTimeInZone_1),
+    z2: toNum(rawData.hrTimeInZone_2),
+    z3: toNum(rawData.hrTimeInZone_3),
+    z4: toNum(rawData.hrTimeInZone_4),
+    z5: toNum(rawData.hrTimeInZone_5),
+  };
+  const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
+  if (total <= 0) return null;
+  return dist;
+}
+
+/** 가중 평균 Zone과 퍼센트 계산 */
+function zonePercents(dist: ZoneDistribution): {
+  total: number;
+  pct: Record<`z${HRZone}`, number>;
+  weighted: number;
+} {
+  const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
+  if (total <= 0) {
+    return {
+      total: 0,
+      pct: { z1: 0, z2: 0, z3: 0, z4: 0, z5: 0 },
+      weighted: 0,
+    };
+  }
+  const pct = {
+    z1: dist.z1 / total,
+    z2: dist.z2 / total,
+    z3: dist.z3 / total,
+    z4: dist.z4 / total,
+    z5: dist.z5 / total,
+  };
+  const weighted = pct.z1 * 1 + pct.z2 * 2 + pct.z3 * 3 + pct.z4 * 4 + pct.z5 * 5;
+  return { total, pct, weighted };
+}
+
+/** 분포 + avgHR(optional) 기반 강도 분류 */
+export function classifyIntensity(args: {
+  zoneDistribution: ZoneDistribution;
+  avgHR?: number | null;
+  lthr?: number | null;
+}): IntensityClassification {
+  const dist = args.zoneDistribution;
+  const { total, pct, weighted } = zonePercents(dist);
+
+  // 대표 Zone: 가중 평균 반올림
+  const estimatedZone = Math.max(
+    1,
+    Math.min(5, Math.round(weighted))
+  ) as HRZone;
+
+  // 강도 점수 (TRIMP 유사): 가중 평균 × 20 → 0~100
+  const intensityScore = total > 0 ? Math.min(100, weighted * 20) : 0;
+
+  // 라벨 분류 (분포 기반 우선, avgHR+LTHR 보조)
+  let label: IntensityLabel = "easy";
+  if (pct.z5 > 0.15 && pct.z4 + pct.z5 > 0.3) {
+    label = "interval";
+  } else if (pct.z5 > 0.05) {
+    label = "max";
+  } else if (pct.z4 > 0.3) {
+    label = "threshold";
+  } else if (pct.z3 > 0.3) {
+    label = "tempo";
+  } else if (pct.z1 > 0.7) {
+    label = "recovery";
+  } else {
+    label = "easy";
+  }
+
+  // avgHR + LTHR이 제공되면 라벨을 보정 (추가 검증)
+  if (args.avgHR && args.avgHR > 0 && args.lthr && args.lthr > 0) {
+    const avgZone = calculateHRZone(args.avgHR, args.lthr);
+    // avgHR 기반 zone이 Z4~Z5인데 분포 기반이 낮으면 threshold 이상으로 보정
+    if (avgZone >= 4 && (label === "easy" || label === "tempo")) {
+      label = "threshold";
+    }
+  }
+
+  return {
+    zoneDistribution: dist,
+    estimatedZone,
+    intensityScore: Number(intensityScore.toFixed(1)),
+    intensityLabel: label,
+  };
+}
+
+/**
+ * Activity.rawData로부터 전체 분류 결과 산출.
+ * 분포 데이터 없으면 null.
+ */
+export function computeIntensityFromRawData(args: {
+  rawData: Record<string, unknown> | null | undefined;
+  avgHR?: number | null;
+  lthr?: number | null;
+}): IntensityClassification | null {
+  const dist = extractZoneDistribution(args.rawData);
+  if (!dist) return null;
+  return classifyIntensity({
+    zoneDistribution: dist,
+    avgHR: args.avgHR,
+    lthr: args.lthr,
+  });
+}

--- a/src/lib/fitness/intensity.ts
+++ b/src/lib/fitness/intensity.ts
@@ -45,9 +45,12 @@ function toNum(v: unknown): number {
   return Number.isFinite(n) && n > 0 ? n : 0;
 }
 
+/** 분포 기반 분류가 의미 있는 최소 zone 시간(초). 이하면 null 처리. */
+export const MIN_ZONE_TOTAL_SEC = 60;
+
 /**
  * Garmin rawData에서 HR Zone 시간 분포를 추출.
- * 모든 zone이 0이면 null 반환 (분포 데이터 없음).
+ * 모든 zone이 0이거나 총합이 MIN_ZONE_TOTAL_SEC 미만이면 null 반환.
  */
 export function extractZoneDistribution(
   rawData: Record<string, unknown> | null | undefined
@@ -61,8 +64,31 @@ export function extractZoneDistribution(
     z5: toNum(rawData.hrTimeInZone_5),
   };
   const total = dist.z1 + dist.z2 + dist.z3 + dist.z4 + dist.z5;
-  if (total <= 0) return null;
+  if (total < MIN_ZONE_TOTAL_SEC) return null;
   return dist;
+}
+
+/** Prisma Json 값이 ZoneDistribution 형태인지 검증 후 타입 안전 캐스팅 */
+export function parseZoneDistribution(
+  value: unknown
+): ZoneDistribution | null {
+  if (!value || typeof value !== "object") return null;
+  const obj = value as Record<string, unknown>;
+  const z1 = Number(obj.z1);
+  const z2 = Number(obj.z2);
+  const z3 = Number(obj.z3);
+  const z4 = Number(obj.z4);
+  const z5 = Number(obj.z5);
+  if (
+    !Number.isFinite(z1) ||
+    !Number.isFinite(z2) ||
+    !Number.isFinite(z3) ||
+    !Number.isFinite(z4) ||
+    !Number.isFinite(z5)
+  ) {
+    return null;
+  }
+  return { z1, z2, z3, z4, z5 };
 }
 
 /** 가중 평균 Zone과 퍼센트 계산 */
@@ -108,12 +134,15 @@ export function classifyIntensity(args: {
   // 강도 점수 (TRIMP 유사): 가중 평균 × 20 → 0~100
   const intensityScore = total > 0 ? Math.min(100, weighted * 20) : 0;
 
-  // 라벨 분류 (분포 기반 우선, avgHR+LTHR 보조)
+  // 라벨 분류 (분포 기반 우선, avgHR+LTHR 보조).
+  // 순서가 중요: 더 구체적인 조건부터 매칭.
   let label: IntensityLabel = "easy";
-  if (pct.z5 > 0.15 && pct.z4 + pct.z5 > 0.3) {
-    label = "interval";
-  } else if (pct.z5 > 0.05) {
+  if (pct.z5 > 0.3) {
+    // Z5에 오래 머무름 → VO2max/무산소 최대치
     label = "max";
+  } else if (pct.z5 > 0.1 && pct.z4 + pct.z5 > 0.3) {
+    // Z4+Z5 반복(인터벌 특유 분포)
+    label = "interval";
   } else if (pct.z4 > 0.3) {
     label = "threshold";
   } else if (pct.z3 > 0.3) {

--- a/src/lib/garmin/fetchers/activities.ts
+++ b/src/lib/garmin/fetchers/activities.ts
@@ -1,6 +1,8 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
+import { computeIntensityFromRawData } from "@/lib/fitness/intensity";
+import { resolveLTHR } from "@/lib/fitness/zones";
 import { withRateLimit } from "../utils";
 
 const PAGE_SIZE = 20;
@@ -13,6 +15,10 @@ export async function syncActivities(
   let synced = 0;
   let start = 0;
   let hasMore = true;
+
+  // M4-5: 강도 분류 시 사용할 LTHR (프로필에서 1회 조회, 없으면 추정)
+  const profile = await prisma.userProfile.findFirst();
+  const lthr = profile ? resolveLTHR(profile) : null;
 
   while (hasMore) {
     const activities = await withRateLimit(() =>
@@ -73,10 +79,30 @@ export async function syncActivities(
         rawData: raw as Prisma.InputJsonValue,
       };
 
+      // M4-5: 강도 자동 분류 (hrTimeInZone_1~5 기반)
+      const intensity = computeIntensityFromRawData({
+        rawData: raw,
+        avgHR: data.avgHR,
+        lthr,
+      });
+      const intensityData = intensity
+        ? {
+            zoneDistribution: intensity.zoneDistribution as unknown as Prisma.InputJsonValue,
+            estimatedZone: intensity.estimatedZone,
+            intensityScore: intensity.intensityScore,
+            intensityLabel: intensity.intensityLabel,
+          }
+        : {
+            zoneDistribution: Prisma.DbNull,
+            estimatedZone: null,
+            intensityScore: null,
+            intensityLabel: null,
+          };
+
       await prisma.activity.upsert({
         where: { garminId: BigInt(a.activityId) },
-        update: data,
-        create: { garminId: BigInt(a.activityId), ...data },
+        update: { ...data, ...intensityData },
+        create: { garminId: BigInt(a.activityId), ...data, ...intensityData },
       });
 
       synced++;

--- a/src/lib/garmin/fetchers/activities.ts
+++ b/src/lib/garmin/fetchers/activities.ts
@@ -2,7 +2,6 @@ import type { GarminConnect } from "@flow-js/garmin-connect";
 import { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
 import { computeIntensityFromRawData } from "@/lib/fitness/intensity";
-import { resolveLTHR } from "@/lib/fitness/zones";
 import { withRateLimit } from "../utils";
 
 const PAGE_SIZE = 20;
@@ -16,9 +15,10 @@ export async function syncActivities(
   let start = 0;
   let hasMore = true;
 
-  // M4-5: 강도 분류 시 사용할 LTHR (프로필에서 1회 조회, 없으면 추정)
+  // M4-5: 강도 분류 시 사용할 실측 LTHR (프로필에서 1회 조회).
+  // 실측값이 없으면 LTHR 기반 보정은 건너뛰고 분포만으로 분류.
   const profile = await prisma.userProfile.findFirst();
-  const lthr = profile ? resolveLTHR(profile) : null;
+  const lthr = profile?.lthr ?? null;
 
   while (hasMore) {
     const activities = await withRateLimit(() =>
@@ -79,19 +79,24 @@ export async function syncActivities(
         rawData: raw as Prisma.InputJsonValue,
       };
 
-      // M4-5: 강도 자동 분류 (hrTimeInZone_1~5 기반)
+      // M4-5: 강도 자동 분류 (hrTimeInZone_1~5 기반).
+      // 분포 추출 실패 시 기존 값을 덮어쓰지 않도록 update/create 동작을 분리.
       const intensity = computeIntensityFromRawData({
         rawData: raw,
         avgHR: data.avgHR,
         lthr,
       });
-      const intensityData = intensity
+      const intensityData: Record<string, unknown> = intensity
         ? {
             zoneDistribution: intensity.zoneDistribution as unknown as Prisma.InputJsonValue,
             estimatedZone: intensity.estimatedZone,
             intensityScore: intensity.intensityScore,
             intensityLabel: intensity.intensityLabel,
           }
+        : {};
+      // create 시에만 빈 값 명시 (upsert update에서는 생략하여 기존 값 유지)
+      const intensityDataCreate: Record<string, unknown> = intensity
+        ? intensityData
         : {
             zoneDistribution: Prisma.DbNull,
             estimatedZone: null,
@@ -102,7 +107,7 @@ export async function syncActivities(
       await prisma.activity.upsert({
         where: { garminId: BigInt(a.activityId) },
         update: { ...data, ...intensityData },
-        create: { garminId: BigInt(a.activityId), ...data, ...intensityData },
+        create: { garminId: BigInt(a.activityId), ...data, ...intensityDataCreate },
       });
 
       synced++;

--- a/src/mcp/tools/fitness.ts
+++ b/src/mcp/tools/fitness.ts
@@ -38,6 +38,10 @@ export async function getActivities(args: { days?: number; type?: string }) {
       elevationGain: true,
       trainingEffect: true,
       vo2maxEstimate: true,
+      // M4-5: 강도 자동 분류
+      estimatedZone: true,
+      intensityLabel: true,
+      intensityScore: true,
     },
   });
 


### PR DESCRIPTION
## 변경 사항

LTHR 기반 Zone 분포/강도 자동 분류. Garmin `hrTimeInZone_1~5`를 활용하여 추가 API 호출 없이 빠르게 구현.

### 추가
- Activity 스키마 확장: `zoneDistribution` (Json), `estimatedZone`, `intensityScore`, `intensityLabel`
- `src/lib/fitness/intensity.ts` — extract / classify / parse 유틸
  - 라벨: `recovery | easy | tempo | threshold | interval | max`
  - MIN_ZONE_TOTAL_SEC=60 이하 활동은 제외 (노이즈 방지)
  - avgHR + 실측 LTHR 있으면 라벨 보정
- Activity 싱크 시 자동 계산 (분포 추출 실패 시 기존 값 유지)
- `scripts/backfill-intensity.ts` (--force 플래그 지원)
- MCP `get_activities` + 활동 상세 UI에 노출

### 검증
- 내 데이터(5개 러닝) backfill → 4개 tempo, 1개 interval 분류 확인
- lint / tsc / build / codex 리뷰 2 라운드 → P0/P1/P2 = 0/0/0

Closes #61

## 테스트 플랜
- [ ] 새 활동 싱크 후 intensity 필드 자동 채워짐
- [ ] 이미 분류된 활동 재싱크 시 기존 값 유지
- [ ] 활동 상세 페이지 IntensityBreakdown 렌더링
- [ ] AI 어드바이저에 "최근 템포 런 있었어?" 질문 → get_activities 응답에 라벨 활용