### PR TITLE
[M4-6] 체중감량 진행 대시보드 (/body 확장) (#63)

### DIFF
--- a/prisma/migrations/20260416150637_add_target_date/migration.sql
+++ b/prisma/migrations/20260416150637_add_target_date/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: M4-6 목표 체중 도달 목표일
+ALTER TABLE "UserProfile" ADD COLUMN "targetDate" TIMESTAMP(3);

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -21,6 +21,7 @@ model UserProfile {
   lthr           Int?                // 젖산역치 심박 (bpm)
   lthrPace       Float?              // LTHR 페이스 (sec/km)
   targetCalories Int?                // 일일 칼로리 목표 (kcal)
+  targetDate     DateTime?           // M4-6: 목표 체중 도달 목표일
   createdAt      DateTime  @default(now())
   updatedAt      DateTime  @updatedAt
 }

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -48,6 +48,12 @@ const PATCH_SCHEMA = z.object({
 
 const DEFAULT_NAME = "사용자";
 
+/** "YYYY-MM-DD" 문자열을 서버 로컬 midnight Date로 파싱 (저장/검증 통일 경로). */
+function parseLocalDate(isoDate: string): Date {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
 /**
  * 싱글톤 UserProfile 조회 또는 생성.
  * `singleton` unique 제약으로 동시 요청 시에도 중복 row 생성 불가.
@@ -95,7 +101,7 @@ export async function PATCH(request: Request) {
     const nextBirthDate =
       data.birthDate !== undefined
         ? data.birthDate
-          ? new Date(data.birthDate)
+          ? parseLocalDate(data.birthDate)
           : null
         : existing.birthDate;
     if (nextLthr !== null) {
@@ -118,22 +124,14 @@ export async function PATCH(request: Request) {
     if (data.name !== undefined) updatePayload.name = data.name;
     if (data.birthDate !== undefined)
       updatePayload.birthDate = data.birthDate
-        ? // 서버 로컬 타임존의 midnight으로 저장 (formatDateLocal 표시와 정합)
-          (() => {
-            const [y, m, d] = data.birthDate.split("-").map(Number);
-            return new Date(y, m - 1, d);
-          })()
+        ? parseLocalDate(data.birthDate)
         : null;
     if (data.height !== undefined) updatePayload.height = data.height;
     if (data.targetWeight !== undefined)
       updatePayload.targetWeight = data.targetWeight;
     if (data.targetDate !== undefined)
       updatePayload.targetDate = data.targetDate
-        ? // 서버 로컬 타임존의 midnight으로 저장 (formatDateLocal 표시와 정합)
-          (() => {
-            const [y, m, d] = data.targetDate.split("-").map(Number);
-            return new Date(y, m - 1, d);
-          })()
+        ? parseLocalDate(data.targetDate)
         : null;
     if (data.restingHRBase !== undefined)
       updatePayload.restingHRBase = data.restingHRBase;

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -25,6 +25,20 @@ const PATCH_SCHEMA = z.object({
   birthDate: birthDateSchema,
   height: z.number().positive().max(300).nullable().optional(),
   targetWeight: z.number().positive().max(500).nullable().optional(),
+  targetDate: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식")
+    .refine((s) => {
+      const [y, m, d] = s.split("-").map(Number);
+      const date = new Date(Date.UTC(y, m - 1, d));
+      return (
+        date.getUTCFullYear() === y &&
+        date.getUTCMonth() === m - 1 &&
+        date.getUTCDate() === d
+      );
+    }, "유효하지 않은 날짜")
+    .nullable()
+    .optional(),
   restingHRBase: z.number().int().min(20).max(150).nullable().optional(),
   maxHR: z.number().int().min(100).max(220).nullable().optional(),
   lthr: z.number().int().min(80).max(220).nullable().optional(),
@@ -109,6 +123,10 @@ export async function PATCH(request: Request) {
     if (data.height !== undefined) updatePayload.height = data.height;
     if (data.targetWeight !== undefined)
       updatePayload.targetWeight = data.targetWeight;
+    if (data.targetDate !== undefined)
+      updatePayload.targetDate = data.targetDate
+        ? new Date(data.targetDate)
+        : null;
     if (data.restingHRBase !== undefined)
       updatePayload.restingHRBase = data.restingHRBase;
     if (data.maxHR !== undefined) updatePayload.maxHR = data.maxHR;

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -118,7 +118,11 @@ export async function PATCH(request: Request) {
     if (data.name !== undefined) updatePayload.name = data.name;
     if (data.birthDate !== undefined)
       updatePayload.birthDate = data.birthDate
-        ? new Date(data.birthDate)
+        ? // 서버 로컬 타임존의 midnight으로 저장 (formatDateLocal 표시와 정합)
+          (() => {
+            const [y, m, d] = data.birthDate.split("-").map(Number);
+            return new Date(y, m - 1, d);
+          })()
         : null;
     if (data.height !== undefined) updatePayload.height = data.height;
     if (data.targetWeight !== undefined)

--- a/src/app/api/profile/route.ts
+++ b/src/app/api/profile/route.ts
@@ -125,7 +125,11 @@ export async function PATCH(request: Request) {
       updatePayload.targetWeight = data.targetWeight;
     if (data.targetDate !== undefined)
       updatePayload.targetDate = data.targetDate
-        ? new Date(data.targetDate)
+        ? // 서버 로컬 타임존의 midnight으로 저장 (formatDateLocal 표시와 정합)
+          (() => {
+            const [y, m, d] = data.targetDate.split("-").map(Number);
+            return new Date(y, m - 1, d);
+          })()
         : null;
     if (data.restingHRBase !== undefined)
       updatePayload.restingHRBase = data.restingHRBase;

--- a/src/app/body/body-client.tsx
+++ b/src/app/body/body-client.tsx
@@ -1,6 +1,18 @@
 "use client";
 
 import { useState } from "react";
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  ComposedChart,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
 import TrendLineChart from "@/components/ui/TrendLineChart";
 
 interface DataPoint {
@@ -16,13 +28,51 @@ interface BodyRecord {
   muscleMass: number | null;
 }
 
+interface CaloriePoint {
+  date: string;
+  intake: number | null;
+  available: number | null;
+  balance: number | null;
+  active: number | null;
+}
+
+interface WeeklySummaryRow {
+  weekStartLabel: string;
+  weekEndLabel: string;
+  avgDailyBalance: number | null;
+  projectedLossKg: number | null;
+  weightChangeKg: number | null;
+  daysWithData: number;
+}
+
+interface WeeklyDistance {
+  weekLabel: string;
+  distanceKm: number;
+}
+
+interface GoalProgress {
+  currentWeight: number | null;
+  targetWeight: number | null;
+  targetDate: string | null;
+  remainingKg: number | null;
+  lostKg: number | null;
+  percentComplete: number | null;
+}
+
 interface BodyClientProps {
   latestWeight: number | null;
   latestBMI: number | null;
   latestBodyFat: number | null;
   weightTrend: DataPoint[];
+  weightMA7: DataPoint[];
+  weightMA14: DataPoint[];
   fatTrend: DataPoint[];
   recentRecords: BodyRecord[];
+  calorieSeries: CaloriePoint[];
+  weeklySummaries: WeeklySummaryRow[];
+  weeklyDistances: WeeklyDistance[];
+  goalProgress: GoalProgress;
+  todayDate: string;
 }
 
 export default function BodyClient({
@@ -30,58 +80,45 @@ export default function BodyClient({
   latestBMI,
   latestBodyFat,
   weightTrend,
+  weightMA7,
+  weightMA14,
   fatTrend,
   recentRecords,
+  calorieSeries,
+  weeklySummaries,
+  weeklyDistances,
+  goalProgress,
 }: BodyClientProps) {
   return (
     <div>
       <div className="mb-8">
-        <h1 className="text-2xl font-semibold mb-1">체성분</h1>
-        <p className="text-dim text-sm">체중 / 체지방 추세</p>
+        <h1 className="text-2xl font-semibold mb-1">체성분 / 감량</h1>
+        <p className="text-dim text-sm">
+          체중 · 체지방 · 칼로리 밸런스 · 감량 진행도
+        </p>
       </div>
+
+      {/* 목표 진행도 */}
+      {goalProgress.targetWeight !== null && (
+        <GoalProgressCard progress={goalProgress} />
+      )}
 
       {/* 최근 수치 */}
       <div className="grid grid-cols-3 gap-3 mb-6">
-        <div className="bg-card border border-border rounded-xl p-4">
-          <div className="text-[11px] text-dim tracking-wider uppercase mb-2">
-            체중
-          </div>
-          <div className="text-2xl font-semibold font-[family-name:var(--font-geist-mono)]">
-            {latestWeight?.toFixed(1) ?? "—"}
-            {latestWeight !== null && (
-              <span className="text-sm text-dim font-normal ml-1">kg</span>
-            )}
-          </div>
-        </div>
-        <div className="bg-card border border-border rounded-xl p-4">
-          <div className="text-[11px] text-dim tracking-wider uppercase mb-2">
-            BMI
-          </div>
-          <div className="text-2xl font-semibold font-[family-name:var(--font-geist-mono)]">
-            {latestBMI?.toFixed(1) ?? "—"}
-          </div>
-        </div>
-        <div className="bg-card border border-border rounded-xl p-4">
-          <div className="text-[11px] text-dim tracking-wider uppercase mb-2">
-            체지방률
-          </div>
-          <div className="text-2xl font-semibold font-[family-name:var(--font-geist-mono)]">
-            {latestBodyFat?.toFixed(1) ?? "—"}
-            {latestBodyFat !== null && (
-              <span className="text-sm text-dim font-normal ml-1">%</span>
-            )}
-          </div>
-        </div>
+        <Stat label="체중" value={latestWeight?.toFixed(1) ?? "—"} unit="kg" />
+        <Stat label="BMI" value={latestBMI?.toFixed(1) ?? "—"} />
+        <Stat
+          label="체지방률"
+          value={latestBodyFat?.toFixed(1) ?? "—"}
+          unit="%"
+        />
       </div>
 
-      {/* 추세 차트 */}
+      {/* 체중 추세 (이동평균 포함) */}
+      <WeightTrendChart raw={weightTrend} ma7={weightMA7} ma14={weightMA14} />
+
+      {/* 체지방률 + 칼로리 밸런스 */}
       <div className="grid grid-cols-1 md:grid-cols-2 gap-3 mb-6">
-        <TrendLineChart
-          title="체중 추세 (30일)"
-          data={weightTrend}
-          color="#60a5fa"
-          unit="kg"
-        />
         {fatTrend.length > 0 && (
           <TrendLineChart
             title="체지방률 추세 (30일)"
@@ -90,10 +127,19 @@ export default function BodyClient({
             unit="%"
           />
         )}
+        <WeeklyDistanceChart data={weeklyDistances} />
       </div>
 
+      {/* 칼로리 밸런스 일별 */}
+      {calorieSeries.length > 0 && <CalorieBalanceChart data={calorieSeries} />}
+
+      {/* 주간 요약 테이블 */}
+      {weeklySummaries.length > 0 && (
+        <WeeklySummaryTable rows={weeklySummaries} />
+      )}
+
       {/* 최근 기록 */}
-      <div className="bg-card border border-border rounded-xl p-5">
+      <div className="bg-card border border-border rounded-xl p-5 mt-6">
         <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
           최근 체중 기록
         </div>
@@ -136,8 +182,387 @@ export default function BodyClient({
       {/* 식단 기록 */}
       <div className="mt-10">
         <h2 className="text-lg font-semibold mb-1">식단 기록</h2>
-        <p className="text-dim text-[12px] mb-4">간단히 기록하면 칼로리를 추정합니다</p>
+        <p className="text-dim text-[12px] mb-4">
+          간단히 기록하면 칼로리를 추정합니다
+        </p>
         <FoodInput />
+      </div>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  unit,
+}: {
+  label: string;
+  value: string;
+  unit?: string;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-xl p-4">
+      <div className="text-[11px] text-dim tracking-wider uppercase mb-2">
+        {label}
+      </div>
+      <div className="text-2xl font-semibold font-[family-name:var(--font-geist-mono)]">
+        {value}
+        {unit && value !== "—" && (
+          <span className="text-sm text-dim font-normal ml-1">{unit}</span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function GoalProgressCard({ progress }: { progress: GoalProgress }) {
+  const { currentWeight, targetWeight, targetDate, remainingKg, lostKg, percentComplete } =
+    progress;
+  return (
+    <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <div className="flex items-center justify-between mb-3">
+        <div className="text-[11px] text-dim tracking-wider uppercase">
+          목표 진행도
+        </div>
+        {targetDate && (
+          <div className="text-[11px] text-dim">목표일: {targetDate}</div>
+        )}
+      </div>
+
+      <div className="flex items-end justify-between mb-3">
+        <div>
+          <div className="text-[11px] text-dim">현재</div>
+          <div className="text-xl font-semibold font-[family-name:var(--font-geist-mono)]">
+            {currentWeight?.toFixed(1) ?? "—"}
+            <span className="text-sm text-dim font-normal ml-1">kg</span>
+          </div>
+        </div>
+        <div className="text-dim">→</div>
+        <div>
+          <div className="text-[11px] text-dim">목표</div>
+          <div className="text-xl font-semibold font-[family-name:var(--font-geist-mono)]">
+            {targetWeight?.toFixed(1) ?? "—"}
+            <span className="text-sm text-dim font-normal ml-1">kg</span>
+          </div>
+        </div>
+        <div>
+          <div className="text-[11px] text-dim">남은</div>
+          <div className="text-xl font-semibold font-[family-name:var(--font-geist-mono)] text-accent">
+            {remainingKg !== null
+              ? `${remainingKg > 0 ? "" : "+"}${Math.abs(remainingKg).toFixed(1)}`
+              : "—"}
+            <span className="text-sm text-dim font-normal ml-1">kg</span>
+          </div>
+        </div>
+      </div>
+
+      {percentComplete !== null && (
+        <>
+          <div className="h-2 rounded bg-surface overflow-hidden mb-2">
+            <div
+              className="h-full bg-accent rounded"
+              style={{ width: `${percentComplete}%` }}
+            />
+          </div>
+          <div className="flex justify-between text-[11px] text-dim">
+            <span>
+              {lostKg !== null && `${lostKg.toFixed(1)}kg 감량`}
+            </span>
+            <span>{percentComplete.toFixed(0)}% 진행</span>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+function WeightTrendChart({
+  raw,
+  ma7,
+  ma14,
+}: {
+  raw: DataPoint[];
+  ma7: DataPoint[];
+  ma14: DataPoint[];
+}) {
+  if (raw.length === 0) {
+    return (
+      <div className="bg-card border border-border rounded-xl p-5 mb-6 text-center text-dim text-[13px]">
+        체중 데이터 없음
+      </div>
+    );
+  }
+  // 모든 날짜를 합쳐서 렌더 (MA는 해당 날짜에만 점 표시)
+  const map = new Map<string, { date: string; raw?: number; ma7?: number; ma14?: number }>();
+  for (const p of raw) {
+    if (p.value === null) continue;
+    map.set(p.date, { date: p.date, raw: p.value });
+  }
+  for (const p of ma7) {
+    if (p.value === null) continue;
+    const existing = map.get(p.date) ?? { date: p.date };
+    existing.ma7 = p.value;
+    map.set(p.date, existing);
+  }
+  for (const p of ma14) {
+    if (p.value === null) continue;
+    const existing = map.get(p.date) ?? { date: p.date };
+    existing.ma14 = p.value;
+    map.set(p.date, existing);
+  }
+  const data = Array.from(map.values()).sort((a, b) =>
+    a.date.localeCompare(b.date)
+  );
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-[11px] text-dim tracking-wider uppercase">
+          체중 추세 (30일)
+        </div>
+        <div className="flex gap-3 text-[10px] text-dim">
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-full bg-[#60a5fa80]" />
+            일별
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-0.5 bg-[#22c55e]" />
+            7일 평균
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-0.5 bg-[#a78bfa]" />
+            14일 평균
+          </span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <ComposedChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -10 }}>
+          <CartesianGrid stroke="#1e1e1e" vertical={false} />
+          <XAxis
+            dataKey="date"
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+            tickFormatter={(v: string) => v.slice(5)}
+          />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+            domain={["dataMin - 0.5", "dataMax + 0.5"]}
+            tickFormatter={(v: number) => v.toFixed(1)}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "#0a0a0a",
+              border: "1px solid #1e1e1e",
+              fontSize: 12,
+              borderRadius: 6,
+            }}
+            formatter={(v) => {
+              const n = typeof v === "number" ? v : Number(v);
+              return Number.isFinite(n) ? `${n.toFixed(2)} kg` : "—";
+            }}
+          />
+          <Bar dataKey="raw" fill="#60a5fa80" name="일별" />
+          <Line
+            type="monotone"
+            dataKey="ma7"
+            stroke="#22c55e"
+            strokeWidth={2}
+            dot={false}
+            name="7일 평균"
+          />
+          <Line
+            type="monotone"
+            dataKey="ma14"
+            stroke="#a78bfa"
+            strokeWidth={2}
+            strokeDasharray="4 4"
+            dot={false}
+            name="14일 평균"
+          />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function CalorieBalanceChart({ data }: { data: CaloriePoint[] }) {
+  const chartData = data.map((d) => ({
+    date: d.date,
+    intake: d.intake,
+    available: d.available,
+    balance: d.balance,
+    deficit: d.balance !== null && d.balance < 0 ? d.balance : null,
+    surplus: d.balance !== null && d.balance > 0 ? d.balance : null,
+  }));
+
+  return (
+    <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <div className="text-[11px] text-dim tracking-wider uppercase">
+          칼로리 밸런스 (30일)
+        </div>
+        <div className="flex gap-3 text-[10px] text-dim">
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-sm bg-[#22c55e]" />
+            결손
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-2 h-2 rounded-sm bg-[#ef4444]" />
+            잉여
+          </span>
+          <span className="flex items-center gap-1">
+            <span className="w-3 h-0.5 bg-[#f59e0b]" />
+            섭취가능
+          </span>
+        </div>
+      </div>
+      <ResponsiveContainer width="100%" height={200}>
+        <ComposedChart data={chartData} margin={{ top: 8, right: 8, bottom: 0, left: -10 }}>
+          <CartesianGrid stroke="#1e1e1e" vertical={false} />
+          <XAxis
+            dataKey="date"
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+            tickFormatter={(v: string) => v.slice(5)}
+          />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+            tickFormatter={(v: number) =>
+              v === 0 ? "0" : v > 0 ? `+${v}` : String(v)
+            }
+          />
+          <ReferenceLine y={0} stroke="#333" />
+          <Tooltip
+            contentStyle={{
+              background: "#0a0a0a",
+              border: "1px solid #1e1e1e",
+              fontSize: 12,
+              borderRadius: 6,
+            }}
+            formatter={(v) => {
+              const n = typeof v === "number" ? v : Number(v);
+              if (!Number.isFinite(n)) return "—";
+              return `${n > 0 ? "+" : ""}${n} kcal`;
+            }}
+          />
+          <Bar dataKey="deficit" fill="#22c55e" name="결손" />
+          <Bar dataKey="surplus" fill="#ef4444" name="잉여" />
+        </ComposedChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function WeeklyDistanceChart({ data }: { data: WeeklyDistance[] }) {
+  if (data.length === 0) {
+    return (
+      <div className="bg-card border border-border rounded-xl p-5 text-center text-dim text-[13px]">
+        러닝 데이터 없음
+      </div>
+    );
+  }
+  return (
+    <div className="bg-card border border-border rounded-xl p-5">
+      <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+        주간 러닝 거리 (8주)
+      </div>
+      <ResponsiveContainer width="100%" height={160}>
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 0, left: -10 }}>
+          <CartesianGrid stroke="#1e1e1e" vertical={false} />
+          <XAxis
+            dataKey="weekLabel"
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+          />
+          <YAxis
+            axisLine={false}
+            tickLine={false}
+            tick={{ fill: "#666", fontSize: 10 }}
+            tickFormatter={(v: number) => `${v}`}
+          />
+          <Tooltip
+            contentStyle={{
+              background: "#0a0a0a",
+              border: "1px solid #1e1e1e",
+              fontSize: 12,
+              borderRadius: 6,
+            }}
+            formatter={(v) => {
+              const n = typeof v === "number" ? v : Number(v);
+              return Number.isFinite(n) ? `${n} km` : "—";
+            }}
+          />
+          <Bar dataKey="distanceKm" fill="#22c55e" name="거리" />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+function WeeklySummaryTable({ rows }: { rows: WeeklySummaryRow[] }) {
+  return (
+    <div className="bg-card border border-border rounded-xl p-5 mb-6">
+      <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+        주간 요약 (최근 4주)
+      </div>
+      <div className="overflow-x-auto">
+        <table className="w-full text-[12px]">
+          <thead>
+            <tr className="text-dim border-b border-border">
+              <th className="text-left py-2 font-normal">주</th>
+              <th className="text-right py-2 font-normal">평균 결손</th>
+              <th className="text-right py-2 font-normal">예상 감량</th>
+              <th className="text-right py-2 font-normal">실제 감량</th>
+              <th className="text-right py-2 font-normal">데이터</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((r) => {
+              const deficitClass =
+                r.avgDailyBalance === null
+                  ? "text-dim"
+                  : r.avgDailyBalance <= -1000
+                    ? "text-yellow-400"
+                    : r.avgDailyBalance < 0
+                      ? "text-accent"
+                      : "text-red-400";
+              return (
+                <tr key={r.weekStartLabel} className="border-b border-border/50">
+                  <td className="py-2">
+                    {r.weekStartLabel.slice(5)} ~ {r.weekEndLabel.slice(5)}
+                  </td>
+                  <td
+                    className={`text-right font-[family-name:var(--font-geist-mono)] ${deficitClass}`}
+                  >
+                    {r.avgDailyBalance !== null
+                      ? `${r.avgDailyBalance > 0 ? "+" : ""}${r.avgDailyBalance}`
+                      : "—"}
+                  </td>
+                  <td className="text-right font-[family-name:var(--font-geist-mono)] text-sub">
+                    {r.projectedLossKg !== null
+                      ? `${r.projectedLossKg.toFixed(2)} kg`
+                      : "—"}
+                  </td>
+                  <td className="text-right font-[family-name:var(--font-geist-mono)] text-sub">
+                    {r.weightChangeKg !== null
+                      ? `${r.weightChangeKg > 0 ? "-" : "+"}${Math.abs(r.weightChangeKg).toFixed(2)} kg`
+                      : "—"}
+                  </td>
+                  <td className="text-right text-dim">
+                    {r.daysWithData}/7일
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
       </div>
     </div>
   );
@@ -147,7 +572,9 @@ function FoodInput() {
   const [desc, setDesc] = useState("");
   const [meal, setMeal] = useState("lunch");
   const [loading, setLoading] = useState(false);
-  const [logs, setLogs] = useState<{ description: string; estimatedKcal: number; mealType: string }[]>([]);
+  const [logs, setLogs] = useState<
+    { description: string; estimatedKcal: number; mealType: string }[]
+  >([]);
 
   async function submit(e: React.FormEvent) {
     e.preventDefault();
@@ -210,7 +637,9 @@ function FoodInput() {
           {logs.map((l, i) => (
             <div key={i} className="flex items-center justify-between text-[13px]">
               <div>
-                <span className="text-dim mr-2">{mealLabels[l.mealType] ?? l.mealType}</span>
+                <span className="text-dim mr-2">
+                  {mealLabels[l.mealType] ?? l.mealType}
+                </span>
                 <span>{l.description}</span>
               </div>
               <span className="font-[family-name:var(--font-geist-mono)]">

--- a/src/app/body/body-client.tsx
+++ b/src/app/body/body-client.tsx
@@ -413,10 +413,6 @@ function CalorieBalanceChart({ data }: { data: CaloriePoint[] }) {
             <span className="w-2 h-2 rounded-sm bg-[#ef4444]" />
             잉여
           </span>
-          <span className="flex items-center gap-1">
-            <span className="w-3 h-0.5 bg-[#f59e0b]" />
-            섭취가능
-          </span>
         </div>
       </div>
       <ResponsiveContainer width="100%" height={200}>

--- a/src/app/body/body-client.tsx
+++ b/src/app/body/body-client.tsx
@@ -548,7 +548,8 @@ function WeeklySummaryTable({ rows }: { rows: WeeklySummaryRow[] }) {
                   </td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)] text-sub">
                     {r.weightChangeKg !== null
-                      ? `${r.weightChangeKg > 0 ? "-" : "+"}${Math.abs(r.weightChangeKg).toFixed(2)} kg`
+                      ? // weightChangeKg > 0 = 감량 → "1.50 kg", < 0 = 증가 → "-1.50 kg"
+                        `${r.weightChangeKg >= 0 ? "" : "-"}${Math.abs(r.weightChangeKg).toFixed(2)} kg`
                       : "—"}
                   </td>
                   <td className="text-right text-dim">

--- a/src/app/body/page.tsx
+++ b/src/app/body/page.tsx
@@ -21,7 +21,7 @@ export default async function BodyPage() {
   const thirtyDaysAgo = daysAgoLocal(30);
   const sixtyDaysAgo = daysAgoLocal(60);
 
-  const [latest, weightRecent, fatTrend, recentRecords, profile, balances, weeklyRuns, earliestWeight] =
+  const [latest, weightRecent, fatTrend, recentRecords, profile, balances, weeklyRuns, maxWeightRecord] =
     await Promise.all([
       prisma.bodyComposition.findFirst({ orderBy: { date: "desc" } }),
       prisma.bodyComposition.findMany({
@@ -65,8 +65,9 @@ export default async function BodyPage() {
         select: { startTime: true, distance: true },
         orderBy: { startTime: "asc" },
       }),
+      // 감량 시작점: 전 기간 중 가장 높았던 체중 (earliest가 아닌 max)
       prisma.bodyComposition.findFirst({
-        orderBy: { date: "asc" },
+        orderBy: { weight: "desc" },
         select: { weight: true, date: true },
       }),
     ]);
@@ -103,15 +104,15 @@ export default async function BodyPage() {
     );
   }
 
-  // 주간 러닝 거리 (최근 8주)
+  // 주간 러닝 거리 (최근 8주). weekStart(inclusive) ~ weekEnd(exclusive)로 경계 중복 방지.
   const weeklyDistances: { weekLabel: string; distanceKm: number }[] = [];
   for (let i = 7; i >= 0; i--) {
     const weekStart = daysAgoLocal(i * 7 + 6);
-    const weekEnd = daysAgoLocal(i * 7 - 1);
+    const weekEndExclusive = daysAgoLocal(i * 7 - 1); // 다음 주 시작 (미포함)
     const weekRuns = weeklyRuns.filter(
       (r) =>
         r.startTime.getTime() >= weekStart.getTime() &&
-        r.startTime.getTime() <= weekEnd.getTime()
+        r.startTime.getTime() < weekEndExclusive.getTime()
     );
     const totalMeters = weekRuns.reduce((s, r) => s + (r.distance ?? 0), 0);
     weeklyDistances.push({
@@ -120,10 +121,10 @@ export default async function BodyPage() {
     });
   }
 
-  // 목표 진행도
+  // 목표 진행도 (startWeight = 전 기간 최고 체중을 감량 시작점으로 사용)
   const goalProgress = computeGoalProgress({
     currentWeight: latest?.weight ?? null,
-    startWeight: earliestWeight?.weight ?? null,
+    startWeight: maxWeightRecord?.weight ?? null,
     targetWeight: profile?.targetWeight ?? null,
   });
 

--- a/src/app/body/page.tsx
+++ b/src/app/body/page.tsx
@@ -1,5 +1,10 @@
 import prisma from "@/lib/prisma";
 import { formatDateLocal } from "@/lib/format";
+import {
+  movingAverage,
+  summarizeWeek,
+  computeGoalProgress,
+} from "@/lib/fitness/weight-trend";
 import BodyClient from "./body-client";
 
 export const dynamic = "force-dynamic";
@@ -12,42 +17,139 @@ function daysAgoLocal(n: number): Date {
 }
 
 export default async function BodyPage() {
+  const today = daysAgoLocal(0);
   const thirtyDaysAgo = daysAgoLocal(30);
+  const sixtyDaysAgo = daysAgoLocal(60);
 
-  const [latest, weightTrend, fatTrend, recentRecords] = await Promise.all([
-    prisma.bodyComposition.findFirst({ orderBy: { date: "desc" } }),
-    prisma.bodyComposition.findMany({
-      where: { date: { gte: thirtyDaysAgo } },
-      select: { date: true, weight: true },
-      orderBy: { date: "asc" },
-    }),
-    prisma.bodyComposition.findMany({
-      where: { date: { gte: thirtyDaysAgo }, bodyFat: { not: null } },
-      select: { date: true, bodyFat: true },
-      orderBy: { date: "asc" },
-    }),
-    prisma.bodyComposition.findMany({
-      where: { date: { gte: daysAgoLocal(14) } },
-      orderBy: { date: "desc" },
-      select: {
-        date: true,
-        weight: true,
-        bmi: true,
-        bodyFat: true,
-        muscleMass: true,
-      },
-    }),
-  ]);
+  const [latest, weightRecent, fatTrend, recentRecords, profile, balances, weeklyRuns, earliestWeight] =
+    await Promise.all([
+      prisma.bodyComposition.findFirst({ orderBy: { date: "desc" } }),
+      prisma.bodyComposition.findMany({
+        where: { date: { gte: sixtyDaysAgo } },
+        select: { date: true, weight: true },
+        orderBy: { date: "asc" },
+      }),
+      prisma.bodyComposition.findMany({
+        where: { date: { gte: thirtyDaysAgo }, bodyFat: { not: null } },
+        select: { date: true, bodyFat: true },
+        orderBy: { date: "asc" },
+      }),
+      prisma.bodyComposition.findMany({
+        where: { date: { gte: daysAgoLocal(14) } },
+        orderBy: { date: "desc" },
+        select: {
+          date: true,
+          weight: true,
+          bmi: true,
+          bodyFat: true,
+          muscleMass: true,
+        },
+      }),
+      prisma.userProfile.findFirst(),
+      prisma.dailySummary.findMany({
+        where: { date: { gte: daysAgoLocal(30) } },
+        select: {
+          date: true,
+          calorieBalance: true,
+          estimatedIntakeCalories: true,
+          availableCalories: true,
+          activeCalories: true,
+        },
+        orderBy: { date: "asc" },
+      }),
+      prisma.activity.findMany({
+        where: {
+          startTime: { gte: daysAgoLocal(56) },
+          activityType: { contains: "running" },
+        },
+        select: { startTime: true, distance: true },
+        orderBy: { startTime: "asc" },
+      }),
+      prisma.bodyComposition.findFirst({
+        orderBy: { date: "asc" },
+        select: { weight: true, date: true },
+      }),
+    ]);
+
+  // 체중 이동평균 7일
+  const weightRecords = weightRecent.map((r) => ({
+    date: r.date,
+    weight: r.weight,
+  }));
+  const weightMA7 = movingAverage(weightRecords, 7);
+  const weightMA14 = movingAverage(weightRecords, 14);
+
+  // 최근 30일 칼로리 밸런스 일별
+  const calorieSeries = balances.map((b) => ({
+    date: formatDateLocal(b.date),
+    intake: b.estimatedIntakeCalories,
+    available: b.availableCalories,
+    balance: b.calorieBalance,
+    active: b.activeCalories,
+  }));
+
+  // 주간 요약 (최근 4주)
+  const weeklySummaries = [];
+  for (let i = 0; i < 4; i++) {
+    const weekEnd = daysAgoLocal(i * 7);
+    const weekStart = daysAgoLocal(i * 7 + 7);
+    weeklySummaries.push(
+      summarizeWeek({
+        balances,
+        weights: weightRecords,
+        weekStart,
+        weekEnd,
+      })
+    );
+  }
+
+  // 주간 러닝 거리 (최근 8주)
+  const weeklyDistances: { weekLabel: string; distanceKm: number }[] = [];
+  for (let i = 7; i >= 0; i--) {
+    const weekStart = daysAgoLocal(i * 7 + 6);
+    const weekEnd = daysAgoLocal(i * 7 - 1);
+    const weekRuns = weeklyRuns.filter(
+      (r) =>
+        r.startTime.getTime() >= weekStart.getTime() &&
+        r.startTime.getTime() <= weekEnd.getTime()
+    );
+    const totalMeters = weekRuns.reduce((s, r) => s + (r.distance ?? 0), 0);
+    weeklyDistances.push({
+      weekLabel: formatDateLocal(weekStart).slice(5), // MM-DD
+      distanceKm: Number((totalMeters / 1000).toFixed(1)),
+    });
+  }
+
+  // 목표 진행도
+  const goalProgress = computeGoalProgress({
+    currentWeight: latest?.weight ?? null,
+    startWeight: earliestWeight?.weight ?? null,
+    targetWeight: profile?.targetWeight ?? null,
+  });
 
   return (
     <BodyClient
       latestWeight={latest?.weight ?? null}
       latestBMI={latest?.bmi ?? null}
       latestBodyFat={latest?.bodyFat ?? null}
-      weightTrend={weightTrend.map((r) => ({
-        date: formatDateLocal(r.date),
-        value: r.weight,
-      }))}
+      weightTrend={weightRecords
+        .filter((r) => r.date.getTime() >= thirtyDaysAgo.getTime())
+        .map((r) => ({
+          date: formatDateLocal(r.date),
+          value: r.weight,
+        }))}
+      weightMA7={weightMA7
+        .filter((p) => p.date.getTime() >= thirtyDaysAgo.getTime())
+        .map((p) => ({
+          date: formatDateLocal(p.date),
+          value: p.avg,
+        }))}
+      weightMA14={weightMA14
+        .filter((p) => p.date.getTime() >= thirtyDaysAgo.getTime())
+        .map((p) => ({
+          date: formatDateLocal(p.date),
+          value: p.avg,
+        }))}
       fatTrend={fatTrend.map((r) => ({
         date: formatDateLocal(r.date),
         value: r.bodyFat,
@@ -59,6 +161,29 @@ export default async function BodyPage() {
         bodyFat: r.bodyFat,
         muscleMass: r.muscleMass,
       }))}
+      calorieSeries={calorieSeries}
+      weeklySummaries={weeklySummaries.map((s) => ({
+        weekStartLabel: formatDateLocal(s.weekStart),
+        weekEndLabel: formatDateLocal(
+          new Date(s.weekEnd.getTime() - 1)
+        ),
+        avgDailyBalance: s.avgDailyBalance,
+        projectedLossKg: s.projectedLossKg,
+        weightChangeKg: s.weightChangeKg,
+        daysWithData: s.daysWithData,
+      }))}
+      weeklyDistances={weeklyDistances}
+      goalProgress={{
+        currentWeight: latest?.weight ?? null,
+        targetWeight: profile?.targetWeight ?? null,
+        targetDate: profile?.targetDate
+          ? formatDateLocal(profile.targetDate)
+          : null,
+        remainingKg: goalProgress.remainingKg,
+        lostKg: goalProgress.lostKg,
+        percentComplete: goalProgress.percentComplete,
+      }}
+      todayDate={formatDateLocal(today)}
     />
   );
 }

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -1,4 +1,5 @@
 import prisma from "@/lib/prisma";
+import { formatDateLocal } from "@/lib/format";
 import ProfileClient from "./profile-client";
 
 export const dynamic = "force-dynamic";
@@ -9,13 +10,12 @@ export default async function ProfilePage() {
     <ProfileClient
       initial={{
         name: profile?.name ?? "사용자",
-        birthDate: profile?.birthDate
-          ? profile.birthDate.toISOString().slice(0, 10)
-          : "",
+        // 서버 로컬 midnight으로 저장된 값 → 로컬 타임존 기준 YYYY-MM-DD 추출
+        birthDate: profile?.birthDate ? formatDateLocal(profile.birthDate) : "",
         height: profile?.height ?? null,
         targetWeight: profile?.targetWeight ?? null,
         targetDate: profile?.targetDate
-          ? profile.targetDate.toISOString().slice(0, 10)
+          ? formatDateLocal(profile.targetDate)
           : "",
         restingHRBase: profile?.restingHRBase ?? null,
         maxHR: profile?.maxHR ?? null,

--- a/src/app/settings/profile/page.tsx
+++ b/src/app/settings/profile/page.tsx
@@ -14,6 +14,9 @@ export default async function ProfilePage() {
           : "",
         height: profile?.height ?? null,
         targetWeight: profile?.targetWeight ?? null,
+        targetDate: profile?.targetDate
+          ? profile.targetDate.toISOString().slice(0, 10)
+          : "",
         restingHRBase: profile?.restingHRBase ?? null,
         maxHR: profile?.maxHR ?? null,
         lthr: profile?.lthr ?? null,

--- a/src/app/settings/profile/profile-client.tsx
+++ b/src/app/settings/profile/profile-client.tsx
@@ -7,6 +7,7 @@ interface ProfileValues {
   birthDate: string; // "YYYY-MM-DD" or ""
   height: number | null;
   targetWeight: number | null;
+  targetDate: string; // "YYYY-MM-DD" or ""
   restingHRBase: number | null;
   maxHR: number | null;
   lthr: number | null;
@@ -53,6 +54,7 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
     height: initial.height === null ? "" : String(initial.height),
     targetWeight:
       initial.targetWeight === null ? "" : String(initial.targetWeight),
+    targetDate: initial.targetDate,
     restingHRBase:
       initial.restingHRBase === null ? "" : String(initial.restingHRBase),
     maxHR: initial.maxHR === null ? "" : String(initial.maxHR),
@@ -89,6 +91,7 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
       birthDate: values.birthDate || null,
       height: toNumOrNull(values.height),
       targetWeight: toNumOrNull(values.targetWeight),
+      targetDate: values.targetDate || null,
       restingHRBase: toNumOrNull(values.restingHRBase),
       maxHR: toNumOrNull(values.maxHR),
       lthr: toNumOrNull(values.lthr),
@@ -177,6 +180,15 @@ export default function ProfileClient({ initial }: ProfileClientProps) {
               />
             </Field>
           </div>
+
+          <Field label="목표 도달 예정일" hint="감량 진행도 계산에 사용">
+            <input
+              type="date"
+              value={values.targetDate}
+              onChange={(e) => setField("targetDate", e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </Field>
         </section>
 
         {/* 심박 Zone */}

--- a/src/lib/fitness/weight-trend.ts
+++ b/src/lib/fitness/weight-trend.ts
@@ -1,0 +1,156 @@
+/**
+ * 체중감량 분석 유틸 (M4-6).
+ *
+ * - movingAverage: N일 이동평균 계산 (센트럴이 아닌 단말 기준, 과거 N-1일 포함)
+ * - projectWeightLossKg: 일평균 칼로리 결손으로 주간 예상 감량 추정
+ * - weeklyAverage: 최근 N일 평균
+ */
+
+const KCAL_PER_KG_FAT = 7700;
+
+export interface WeightRecord {
+  date: Date;
+  weight: number;
+}
+
+export interface MovingAvgPoint {
+  date: Date;
+  avg: number;
+}
+
+/**
+ * 단말(trailing) 기준 N일 이동평균.
+ * 창 내 최소 1개 데이터가 있어야 산출.
+ */
+export function movingAverage(
+  records: readonly WeightRecord[],
+  window: number
+): MovingAvgPoint[] {
+  if (window <= 0) return [];
+  const sorted = [...records].sort(
+    (a, b) => a.date.getTime() - b.date.getTime()
+  );
+  const result: MovingAvgPoint[] = [];
+  for (let i = 0; i < sorted.length; i++) {
+    const start = Math.max(0, i - window + 1);
+    const slice = sorted.slice(start, i + 1);
+    if (slice.length === 0) continue;
+    const sum = slice.reduce((s, r) => s + r.weight, 0);
+    result.push({
+      date: sorted[i].date,
+      avg: Number((sum / slice.length).toFixed(2)),
+    });
+  }
+  return result;
+}
+
+/**
+ * 일평균 결손(kcal/day, 음수) → 주간 예상 감량(kg).
+ * 1kg 체지방 ≈ 7700kcal 가정.
+ */
+export function projectWeightLossKg(avgDailyDeficit: number): number {
+  // avgDailyDeficit은 음수일 때 감량 → 절대값 사용
+  const weeklyDeficit = Math.abs(avgDailyDeficit) * 7;
+  return Number((weeklyDeficit / KCAL_PER_KG_FAT).toFixed(2));
+}
+
+export interface WeeklySummary {
+  weekStart: Date;
+  weekEnd: Date;
+  avgDailyBalance: number | null; // kcal/day (음수 = 결손)
+  daysWithData: number;
+  projectedLossKg: number | null; // 주간 예상 감량 (+ = 감량, 0/null = 데이터 부족)
+  weightChangeKg: number | null; // 실제 체중 변화 (+ = 감소)
+  actualKg: { first: number; last: number } | null;
+}
+
+/** 최근 7일(또는 지정 기간)의 평균 결손 및 실제 체중 변화 요약 */
+export function summarizeWeek(args: {
+  balances: readonly { date: Date; calorieBalance: number | null }[];
+  weights: readonly WeightRecord[];
+  weekStart: Date;
+  weekEnd: Date;
+}): WeeklySummary {
+  const inRange = <T extends { date: Date }>(r: T) =>
+    r.date.getTime() >= args.weekStart.getTime() &&
+    r.date.getTime() < args.weekEnd.getTime();
+
+  const bals = args.balances
+    .filter(inRange)
+    .filter((b) => b.calorieBalance !== null) as {
+    date: Date;
+    calorieBalance: number;
+  }[];
+  const daysWithData = bals.length;
+  const avgDailyBalance =
+    daysWithData > 0
+      ? Math.round(bals.reduce((s, b) => s + b.calorieBalance, 0) / daysWithData)
+      : null;
+  const projectedLossKg =
+    avgDailyBalance !== null && avgDailyBalance < 0
+      ? projectWeightLossKg(avgDailyBalance)
+      : avgDailyBalance !== null
+        ? 0
+        : null;
+
+  const weekWeights = args.weights
+    .filter(inRange)
+    .sort((a, b) => a.date.getTime() - b.date.getTime());
+  const actualKg =
+    weekWeights.length >= 2
+      ? {
+          first: weekWeights[0].weight,
+          last: weekWeights[weekWeights.length - 1].weight,
+        }
+      : null;
+  const weightChangeKg =
+    actualKg !== null
+      ? Number((actualKg.first - actualKg.last).toFixed(2))
+      : null;
+
+  return {
+    weekStart: args.weekStart,
+    weekEnd: args.weekEnd,
+    avgDailyBalance,
+    daysWithData,
+    projectedLossKg,
+    weightChangeKg,
+    actualKg,
+  };
+}
+
+/** 목표 진행도 계산 (백분율 0~100) */
+export function computeGoalProgress(args: {
+  currentWeight: number | null;
+  startWeight: number | null; // 감량 시작 시점 체중 (첫 기록 등)
+  targetWeight: number | null;
+}): {
+  remainingKg: number | null;
+  lostKg: number | null;
+  percentComplete: number | null;
+} {
+  const { currentWeight, startWeight, targetWeight } = args;
+  if (currentWeight === null || targetWeight === null) {
+    return { remainingKg: null, lostKg: null, percentComplete: null };
+  }
+  const remaining = Number((currentWeight - targetWeight).toFixed(2));
+  if (startWeight === null) {
+    return { remainingKg: remaining, lostKg: null, percentComplete: null };
+  }
+  const totalToLose = startWeight - targetWeight;
+  if (totalToLose <= 0) {
+    // 이미 목표 달성 또는 역방향
+    return {
+      remainingKg: remaining,
+      lostKg: Number((startWeight - currentWeight).toFixed(2)),
+      percentComplete: remaining <= 0 ? 100 : 0,
+    };
+  }
+  const lost = startWeight - currentWeight;
+  const percent = Math.max(0, Math.min(100, (lost / totalToLose) * 100));
+  return {
+    remainingKg: remaining,
+    lostKg: Number(lost.toFixed(2)),
+    percentComplete: Number(percent.toFixed(1)),
+  };
+}

--- a/src/lib/fitness/weight-trend.ts
+++ b/src/lib/fitness/weight-trend.ts
@@ -122,7 +122,7 @@ export function summarizeWeek(args: {
 /** 목표 진행도 계산 (백분율 0~100) */
 export function computeGoalProgress(args: {
   currentWeight: number | null;
-  startWeight: number | null; // 감량 시작 시점 체중 (첫 기록 등)
+  startWeight: number | null; // 감량 시작 시점 체중 (현재보다 이전의 최대 체중)
   targetWeight: number | null;
 }): {
   remainingKg: number | null;
@@ -134,18 +134,18 @@ export function computeGoalProgress(args: {
     return { remainingKg: null, lostKg: null, percentComplete: null };
   }
   const remaining = Number((currentWeight - targetWeight).toFixed(2));
-  if (startWeight === null) {
+
+  // startWeight가 없거나, currentWeight보다 작거나 같거나, targetWeight보다 작으면
+  // 감량 시작점으로 볼 수 없어 진행률 계산 불가 (remaining만 표시).
+  if (
+    startWeight === null ||
+    startWeight <= currentWeight ||
+    startWeight <= targetWeight
+  ) {
     return { remainingKg: remaining, lostKg: null, percentComplete: null };
   }
+
   const totalToLose = startWeight - targetWeight;
-  if (totalToLose <= 0) {
-    // 이미 목표 달성 또는 역방향
-    return {
-      remainingKg: remaining,
-      lostKg: Number((startWeight - currentWeight).toFixed(2)),
-      percentComplete: remaining <= 0 ? 100 : 0,
-    };
-  }
   const lost = startWeight - currentWeight;
   const percent = Math.max(0, Math.min(100, (lost / totalToLose) * 100));
   return {

--- a/src/lib/fitness/weight-trend.ts
+++ b/src/lib/fitness/weight-trend.ts
@@ -18,9 +18,13 @@ export interface MovingAvgPoint {
   avg: number;
 }
 
+const DAY_MS = 24 * 60 * 60 * 1000;
+
 /**
  * 단말(trailing) 기준 N일 이동평균.
- * 창 내 최소 1개 데이터가 있어야 산출.
+ * 각 레코드 D의 이동평균 = [D - (N-1)일, D] 범위에 속한 모든 기록의 평균.
+ * 창은 레코드 개수가 아닌 "달력상 일수" 기준이므로, 기록이 드문드문 있어도
+ * 의미 있는 N일 평균을 반환.
  */
 export function movingAverage(
   records: readonly WeightRecord[],
@@ -32,13 +36,19 @@ export function movingAverage(
   );
   const result: MovingAvgPoint[] = [];
   for (let i = 0; i < sorted.length; i++) {
-    const start = Math.max(0, i - window + 1);
-    const slice = sorted.slice(start, i + 1);
-    if (slice.length === 0) continue;
-    const sum = slice.reduce((s, r) => s + r.weight, 0);
+    const currentDate = sorted[i].date;
+    const windowStartMs = currentDate.getTime() - (window - 1) * DAY_MS;
+    // 달력 일수 기준 창: windowStartMs 이상, currentDate 이하
+    const inWindow = sorted.filter(
+      (r) =>
+        r.date.getTime() >= windowStartMs &&
+        r.date.getTime() <= currentDate.getTime()
+    );
+    if (inWindow.length === 0) continue;
+    const sum = inWindow.reduce((s, r) => s + r.weight, 0);
     result.push({
-      date: sorted[i].date,
-      avg: Number((sum / slice.length).toFixed(2)),
+      date: currentDate,
+      avg: Number((sum / inWindow.length).toFixed(2)),
     });
   }
   return result;
@@ -135,17 +145,23 @@ export function computeGoalProgress(args: {
   }
   const remaining = Number((currentWeight - targetWeight).toFixed(2));
 
-  // startWeight가 없거나, currentWeight보다 작거나 같거나, targetWeight보다 작으면
-  // 감량 시작점으로 볼 수 없어 진행률 계산 불가 (remaining만 표시).
-  if (
-    startWeight === null ||
-    startWeight <= currentWeight ||
-    startWeight <= targetWeight
-  ) {
+  // startWeight가 없거나 targetWeight보다 작으면 감량 방향이 성립하지 않음.
+  if (startWeight === null || startWeight < targetWeight) {
     return { remainingKg: remaining, lostKg: null, percentComplete: null };
   }
 
+  // 이미 목표 도달(startWeight === targetWeight)은 100%
   const totalToLose = startWeight - targetWeight;
+  if (totalToLose === 0) {
+    return {
+      remainingKg: remaining,
+      lostKg: 0,
+      percentComplete: 100,
+    };
+  }
+
+  // 일반 케이스. 감량 시작 = 진행 중 = 감량 완료 전 구간을 포함.
+  // startWeight === currentWeight이면 lost=0 → 0% (초기 상태 표시).
   const lost = startWeight - currentWeight;
   const percent = Math.max(0, Math.min(100, (lost / totalToLose) * 100));
   return {


### PR DESCRIPTION
## 변경 사항

M4-6 스펙의 모든 섹션을 기존 `/body` 페이지에 통합하여 확장.

### 추가 섹션
- **목표 진행도 카드** — 현재/목표/남은 kg + 진행률 바 (startWeight는 전 기간 최대 체중)
- **체중 추세 차트** — 일별 + 7일/14일 이동평균 (ComposedChart)
- **칼로리 밸런스 일별** — 30일 바 차트 (결손 초록/잉여 빨강)
- **주간 요약 테이블** — 최근 4주 평균 결손/예상 감량/실제 감량/데이터 일수
- **주간 러닝 거리** — 8주 바 차트
- **체지방률 추세** — 기존 유지

### 추가
- UserProfile.targetDate 필드 + 마이그레이션
- `src/lib/fitness/weight-trend.ts` — movingAverage / projectWeightLossKg / summarizeWeek / computeGoalProgress
- 프로필 API/UI에 targetDate 지원
- 날짜 저장/표시 정합성: birthDate/targetDate 모두 서버 로컬 midnight 저장 + formatDateLocal 표시

Closes #63

## 체크리스트
- [x] lint / tsc / build 통과
- [x] codex-cli 리뷰 3 라운드 → P0/P1/P2 = 0/0/0

## 코드 리뷰 요약
- 라운드 1: P1 3건(날짜 타임존, 주간 버킷 TZ, startWeight 계산) + P2 2건(범례, 버킷 경계) → 수정
- 라운드 2: P1 1건(표시 toISOString) → 수정
- 라운드 3: **0/0/0 ✅**

## 테스트 플랜
- [ ] /settings/profile에서 목표 체중/목표일 저장 → /body에서 목표 진행도 카드 확인
- [ ] 체중 이동평균(7일/14일) 차트 오버레이 렌더링
- [ ] 칼로리 밸런스 일별 바 차트 — 결손/잉여 색상 구분
- [ ] 주간 요약 테이블 — 4주치 데이터 표시
- [ ] 프로필에서 날짜 저장/재진입 시 동일 날짜 유지 (하루 밀림 없음)