### PR TITLE
[M4-7] 체지방률 트래킹 (수동 입력) (#65)

### DIFF
--- a/prisma/migrations/20260417092418_add_body_source/migration.sql
+++ b/prisma/migrations/20260417092418_add_body_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable: M4-7 체성분 소스 필드
+ALTER TABLE "BodyComposition" ADD COLUMN "source" TEXT NOT NULL DEFAULT 'garmin';

--- a/prisma/migrations/20260417092418_add_body_source/migration.sql
+++ b/prisma/migrations/20260417092418_add_body_source/migration.sql
@@ -1,2 +1,5 @@
 -- AlterTable: M4-7 체성분 소스 필드
 ALTER TABLE "BodyComposition" ADD COLUMN "source" TEXT NOT NULL DEFAULT 'garmin';
+
+-- source 값은 'garmin' 또는 'manual'만 허용
+ALTER TABLE "BodyComposition" ADD CONSTRAINT "BodyComposition_source_check" CHECK ("source" IN ('garmin', 'manual'));

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -150,6 +150,7 @@ model BodyComposition {
   bmi        Float?
   bodyFat    Float?                    // %
   muscleMass Float?                    // kg
+  source     String   @default("garmin") // "garmin" | "manual"
   rawData    Json?
   createdAt  DateTime @default(now())
 }

--- a/src/app/api/body-composition/route.ts
+++ b/src/app/api/body-composition/route.ts
@@ -1,0 +1,75 @@
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import prisma from "@/lib/prisma";
+
+const POST_SCHEMA = z.object({
+  date: z
+    .string()
+    .regex(/^\d{4}-\d{2}-\d{2}$/, "YYYY-MM-DD 형식")
+    .refine((s) => {
+      const [y, m, d] = s.split("-").map(Number);
+      const dt = new Date(Date.UTC(y, m - 1, d));
+      return (
+        dt.getUTCFullYear() === y &&
+        dt.getUTCMonth() === m - 1 &&
+        dt.getUTCDate() === d
+      );
+    }, "유효하지 않은 날짜"),
+  weight: z.number().positive().max(500),
+  bodyFat: z.number().min(1).max(80).nullable().optional(),
+  muscleMass: z.number().positive().max(200).nullable().optional(),
+});
+
+function parseLocalDate(isoDate: string): Date {
+  const [y, m, d] = isoDate.split("-").map(Number);
+  return new Date(y, m - 1, d);
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json().catch(() => ({}));
+    const parsed = POST_SCHEMA.safeParse(body);
+    if (!parsed.success) {
+      return NextResponse.json(
+        { error: "유효하지 않은 입력", issues: parsed.error.issues },
+        { status: 400 }
+      );
+    }
+
+    const { date, weight, bodyFat, muscleMass } = parsed.data;
+    const dayDate = parseLocalDate(date);
+
+    // BMI 계산 (키 정보 있으면)
+    const profile = await prisma.userProfile.findFirst();
+    const heightM = profile?.height ? profile.height / 100 : null;
+    const bmi =
+      heightM && heightM > 0
+        ? Number((weight / (heightM * heightM)).toFixed(1))
+        : null;
+
+    const data = {
+      weight,
+      bmi,
+      bodyFat: bodyFat ?? null,
+      muscleMass: muscleMass ?? null,
+      source: "manual",
+    };
+
+    const record = await prisma.bodyComposition.upsert({
+      where: { date: dayDate },
+      update: data,
+      create: { date: dayDate, ...data },
+    });
+
+    return NextResponse.json({
+      data: {
+        ...record,
+        date: record.date.toISOString(),
+        createdAt: record.createdAt.toISOString(),
+      },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return NextResponse.json({ error: message }, { status: 500 });
+  }
+}

--- a/src/app/body/body-client.tsx
+++ b/src/app/body/body-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState } from "react";
+import { useRouter } from "next/navigation";
 import {
   Bar,
   BarChart,
@@ -665,6 +666,7 @@ function FoodInput() {
 }
 
 function BodyRecordModal({ onClose }: { onClose: () => void }) {
+  const router = useRouter();
   const today = new Date();
   const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
 
@@ -710,7 +712,7 @@ function BodyRecordModal({ onClose }: { onClose: () => void }) {
       setMessage({ type: "success", text: "저장되었습니다" });
       setTimeout(() => {
         onClose();
-        window.location.reload();
+        router.refresh();
       }, 600);
     } catch (err) {
       setMessage({

--- a/src/app/body/body-client.tsx
+++ b/src/app/body/body-client.tsx
@@ -89,14 +89,28 @@ export default function BodyClient({
   weeklyDistances,
   goalProgress,
 }: BodyClientProps) {
+  const [showRecordModal, setShowRecordModal] = useState(false);
+
   return (
     <div>
-      <div className="mb-8">
-        <h1 className="text-2xl font-semibold mb-1">체성분 / 감량</h1>
-        <p className="text-dim text-sm">
-          체중 · 체지방 · 칼로리 밸런스 · 감량 진행도
-        </p>
+      <div className="flex items-center justify-between mb-8">
+        <div>
+          <h1 className="text-2xl font-semibold mb-1">체성분 / 감량</h1>
+          <p className="text-dim text-sm">
+            체중 · 체지방 · 칼로리 밸런스 · 감량 진행도
+          </p>
+        </div>
+        <button
+          onClick={() => setShowRecordModal(true)}
+          className="px-4 py-2 rounded-lg bg-accent text-[#0a0a0a] text-[12px] font-medium hover:bg-accent-hover transition-colors"
+        >
+          체성분 기록
+        </button>
       </div>
+
+      {showRecordModal && (
+        <BodyRecordModal onClose={() => setShowRecordModal(false)} />
+      )}
 
       {/* 목표 진행도 */}
       {goalProgress.targetWeight !== null && (
@@ -649,3 +663,162 @@ function FoodInput() {
     </div>
   );
 }
+
+function BodyRecordModal({ onClose }: { onClose: () => void }) {
+  const today = new Date();
+  const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+
+  const [date, setDate] = useState(todayStr);
+  const [weight, setWeight] = useState("");
+  const [bodyFat, setBodyFat] = useState("");
+  const [muscleMass, setMuscleMass] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [message, setMessage] = useState<{
+    type: "success" | "error";
+    text: string;
+  } | null>(null);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setMessage(null);
+
+    const w = Number(weight);
+    if (!Number.isFinite(w) || w <= 0) {
+      setMessage({ type: "error", text: "체중을 입력하세요" });
+      return;
+    }
+
+    const payload = {
+      date,
+      weight: w,
+      bodyFat: bodyFat ? Number(bodyFat) : null,
+      muscleMass: muscleMass ? Number(muscleMass) : null,
+    };
+
+    setSaving(true);
+    try {
+      const res = await fetch("/api/body-composition", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        setMessage({ type: "error", text: data?.error ?? "저장 실패" });
+        return;
+      }
+      setMessage({ type: "success", text: "저장되었습니다" });
+      setTimeout(() => {
+        onClose();
+        window.location.reload();
+      }, 600);
+    } catch (err) {
+      setMessage({
+        type: "error",
+        text: err instanceof Error ? err.message : "네트워크 오류",
+      });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      onClick={(e) => e.target === e.currentTarget && onClose()}
+    >
+      <div className="bg-[#0a0a0a] border border-[#1e1e1e] rounded-xl p-6 w-full max-w-md mx-4">
+        <div className="flex items-center justify-between mb-5">
+          <h2 className="text-lg font-semibold">체성분 기록</h2>
+          <button
+            onClick={onClose}
+            className="text-dim hover:text-bright text-xl"
+          >
+            &times;
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <label className="block">
+            <div className="text-xs text-sub mb-1.5">날짜</div>
+            <input
+              type="date"
+              value={date}
+              onChange={(e) => setDate(e.target.value)}
+              className={INPUT_CLASS}
+            />
+          </label>
+
+          <label className="block">
+            <div className="text-xs text-sub mb-1.5">
+              체중 (kg) <span className="text-red-400">*</span>
+            </div>
+            <input
+              type="number"
+              step="0.1"
+              value={weight}
+              onChange={(e) => setWeight(e.target.value)}
+              className={INPUT_CLASS}
+              placeholder="75.0"
+              required
+            />
+          </label>
+
+          <div className="grid grid-cols-2 gap-4">
+            <label className="block">
+              <div className="text-xs text-sub mb-1.5">체지방률 (%)</div>
+              <input
+                type="number"
+                step="0.1"
+                value={bodyFat}
+                onChange={(e) => setBodyFat(e.target.value)}
+                className={INPUT_CLASS}
+                placeholder="20.0"
+              />
+            </label>
+            <label className="block">
+              <div className="text-xs text-sub mb-1.5">근육량 (kg)</div>
+              <input
+                type="number"
+                step="0.1"
+                value={muscleMass}
+                onChange={(e) => setMuscleMass(e.target.value)}
+                className={INPUT_CLASS}
+                placeholder="30.0"
+              />
+            </label>
+          </div>
+
+          <div className="flex items-center gap-3 pt-2">
+            <button
+              type="submit"
+              disabled={saving}
+              className="px-5 py-2.5 rounded-md bg-accent text-black text-sm font-medium disabled:opacity-50 transition-opacity"
+            >
+              {saving ? "저장 중..." : "저장"}
+            </button>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-5 py-2.5 rounded-md border border-[#1e1e1e] text-sub text-sm hover:text-bright transition-colors"
+            >
+              취소
+            </button>
+            {message && (
+              <span
+                className={`text-sm ${
+                  message.type === "success" ? "text-accent" : "text-red-400"
+                }`}
+              >
+                {message.text}
+              </span>
+            )}
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+const INPUT_CLASS =
+  "w-full px-3 py-2 rounded-md bg-card border border-[#1e1e1e] text-bright text-sm focus:outline-none focus:border-accent/60 transition-colors";

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -62,28 +62,28 @@ export async function syncBodyComposition(
         rawData: entry as unknown as Prisma.InputJsonValue,
       };
 
-      // M4-7: 원자적 조건부 업데이트로 source="manual" 보호.
-      // 1) 비-manual 레코드만 업데이트 시도.
+      // M4-7: 원자적 조건부 업데이트 + create fallback으로 source="manual" 보호.
+      // 1) 비-manual 레코드만 업데이트 시도 (원자적).
       const updated = await prisma.bodyComposition.updateMany({
         where: { date: dayDate, source: { not: "manual" } },
         data,
       });
-      // 2) 업데이트된 게 없으면 → 레코드 자체가 없거나, manual 레코드가 있음.
-      //    manual이면 skip, 없으면 create.
-      if (updated.count === 0) {
-        const exists = await prisma.bodyComposition.findUnique({
-          where: { date: dayDate },
-          select: { id: true },
-        });
-        if (!exists) {
+      if (updated.count > 0) {
+        synced++;
+      } else {
+        // 2) 업데이트된 게 없으면 → 레코드 자체가 없거나, manual 레코드가 있음.
+        //    create 시도. unique 제약 위반(P2002)이면 manual 레코드 존재 → skip.
+        try {
           await prisma.bodyComposition.create({
             data: { date: dayDate, ...data },
           });
+          synced++;
+        } catch (err) {
+          const code = (err as { code?: string })?.code;
+          if (code !== "P2002") throw err;
+          // manual 레코드 존재 → 보호 (skip, synced 미증가)
         }
-        // exists = true → manual 레코드 → 보호 (skip)
       }
-
-      synced++;
     } catch (error) {
       const msg = error instanceof Error ? error.message : String(error);
       console.warn(`[body-composition] 항목 저장 실패:`, msg);

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -58,24 +58,30 @@ export async function syncBodyComposition(
         bmi: toFloat(entry.bmi),
         bodyFat: toFloat(entry.bodyFat),
         muscleMass: toFloat(entry.muscleMass),
-        source: "garmin",
+        source: "garmin" as const,
         rawData: entry as unknown as Prisma.InputJsonValue,
       };
 
-      // M4-7: source="manual"인 레코드는 Garmin 싱크로 덮어쓰지 않음 (수동 입력 보호).
-      const existing = await prisma.bodyComposition.findUnique({
-        where: { date: dayDate },
-        select: { source: true },
+      // M4-7: 원자적 조건부 업데이트로 source="manual" 보호.
+      // 1) 비-manual 레코드만 업데이트 시도.
+      const updated = await prisma.bodyComposition.updateMany({
+        where: { date: dayDate, source: { not: "manual" } },
+        data,
       });
-      if (existing?.source === "manual") {
-        continue;
+      // 2) 업데이트된 게 없으면 → 레코드 자체가 없거나, manual 레코드가 있음.
+      //    manual이면 skip, 없으면 create.
+      if (updated.count === 0) {
+        const exists = await prisma.bodyComposition.findUnique({
+          where: { date: dayDate },
+          select: { id: true },
+        });
+        if (!exists) {
+          await prisma.bodyComposition.create({
+            data: { date: dayDate, ...data },
+          });
+        }
+        // exists = true → manual 레코드 → 보호 (skip)
       }
-
-      await prisma.bodyComposition.upsert({
-        where: { date: dayDate },
-        update: data,
-        create: { date: dayDate, ...data },
-      });
 
       synced++;
     } catch (error) {

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -58,8 +58,18 @@ export async function syncBodyComposition(
         bmi: toFloat(entry.bmi),
         bodyFat: toFloat(entry.bodyFat),
         muscleMass: toFloat(entry.muscleMass),
+        source: "garmin",
         rawData: entry as unknown as Prisma.InputJsonValue,
       };
+
+      // M4-7: source="manual"인 레코드는 Garmin 싱크로 덮어쓰지 않음 (수동 입력 보호).
+      const existing = await prisma.bodyComposition.findUnique({
+        where: { date: dayDate },
+        select: { source: true },
+      });
+      if (existing?.source === "manual") {
+        continue;
+      }
 
       await prisma.bodyComposition.upsert({
         where: { date: dayDate },


### PR DESCRIPTION
## 변경 사항

BodyComposition에 source 필드를 추가하고 수동 입력 UI를 구현. Garmin 싱크 시 수동 입력 데이터를 보호.

### 추가
- `BodyComposition.source` 필드 ("garmin" | "manual") + CHECK 제약
- POST `/api/body-composition` 수동 입력 API (Zod 검증, BMI 자동 계산)
- `/body` 페이지 "체성분 기록" 버튼 + 모달 (날짜/체중/체지방률/근육량)
- Garmin fetcher: `updateMany(where: { source: { not: "manual" } })` 원자적 보호

Closes #65

## 체크리스트
- [x] lint / tsc / build 통과
- [x] codex-cli 리뷰 2 라운드 → P0/P1/P2 = 0/0/0

## 테스트 플랜
- [ ] 수동 입력 후 Garmin 싱크 → 수동 데이터 유지 확인
- [ ] Garmin 싱크 후 수동 입력 → 수동 데이터로 덮어쓰기 확인
- [ ] 체지방률 추세 차트에 수동 입력값 반영
- [ ] 잘못된 source 값 INSERT 시 CHECK 제약에 의해 거부