### PR TITLE
fix: MCP 서버 크래시 — splits garmin-connect 의존 제거

### DIFF
--- a/src/lib/ai/claude-advisor.ts
+++ b/src/lib/ai/claude-advisor.ts
@@ -28,6 +28,7 @@ function ensureMcpConfig(): string {
         args: [MCP_SERVER_PATH],
         env: {
           DATABASE_URL: process.env.DATABASE_URL ?? "",
+          APP_BASE_URL: `http://localhost:${process.env.PORT ?? "4200"}`,
         },
       },
     },

--- a/src/mcp/tools/splits.ts
+++ b/src/mcp/tools/splits.ts
@@ -132,12 +132,12 @@ export async function getActivitySplits(args: { activityId: string }) {
   }
 
   // 내부 API 경유로 splits 조회 (MCP는 별도 프로세스라 Garmin client 직접 사용 불가).
-  // Next.js 서버의 /api/activities/[id]/splits 를 localhost로 호출.
-  const port = process.env.PORT ?? "4200";
+  // claude-advisor가 MCP env로 APP_BASE_URL을 전달.
+  const baseUrl = process.env.APP_BASE_URL ?? "http://localhost:4200";
   let rawLaps: RawLapDTO[] = [];
   try {
     const res = await fetch(
-      `http://localhost:${port}/api/activities/${activity.id}/splits`
+      `${baseUrl}/api/activities/${activity.id}/splits`
     );
     if (!res.ok) {
       const body = await res.json().catch(() => ({ error: res.statusText }));

--- a/src/mcp/tools/splits.ts
+++ b/src/mcp/tools/splits.ts
@@ -1,5 +1,4 @@
 import prisma from "../prisma";
-import { withReauth } from "@/lib/garmin/client";
 
 interface RawLapDTO {
   distance?: number | null; // meters
@@ -132,18 +131,25 @@ export async function getActivitySplits(args: { activityId: string }) {
     return errorPayload(`활동을 찾을 수 없습니다: ${activityId}`);
   }
 
-  // Garmin API로 splits 조회
+  // 내부 API 경유로 splits 조회 (MCP는 별도 프로세스라 Garmin client 직접 사용 불가).
+  // Next.js 서버의 /api/activities/[id]/splits 를 localhost로 호출.
+  const port = process.env.PORT ?? "4200";
   let rawLaps: RawLapDTO[] = [];
   try {
-    const splits = await withReauth(async (client) =>
-      client.get<{ lapDTOs?: RawLapDTO[] }>(
-        `https://connectapi.garmin.com/activity-service/activity/${activity.garminId}/splits`
-      )
+    const res = await fetch(
+      `http://localhost:${port}/api/activities/${activity.id}/splits`
     );
-    rawLaps = splits.lapDTOs ?? [];
+    if (!res.ok) {
+      const body = await res.json().catch(() => ({ error: res.statusText }));
+      return errorPayload(
+        `Splits 조회 실패 (${res.status}): ${body?.error ?? res.statusText}`
+      );
+    }
+    const body = await res.json();
+    rawLaps = (body.data as RawLapDTO[]) ?? [];
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
-    return errorPayload(`Garmin splits 조회 실패: ${message}`);
+    return errorPayload(`Splits API 호출 실패: ${message}`);
   }
 
   const laps = rawLaps.map(toLapResponse);


### PR DESCRIPTION
## 문제

AI 평가 시 "MCP 도구가 현재 환경에서 직접 연결되지 않아" 메시지 발생.

## 원인

M4-4에서 `src/mcp/tools/splits.ts`가 `withReauth`(`@flow-js/garmin-connect` 의존)를 직접 import.
MCP 서버는 ESM(`server.mjs`)으로 빌드되는데, garmin-connect는 CJS로 `require("path")`를 사용.
ESM에서 CJS dynamic require가 불가하여 MCP 서버가 시작 시 크래시:

\`\`\`
Error: Dynamic require of "path" is not supported
\`\`\`

## 수정

`withReauth` 직접 호출 → 내부 `/api/activities/[id]/splits` HTTP 호출로 전환.
MCP 서버는 읽기 전용 DB + localhost API 경유 패턴을 유지하여 garmin-connect 의존 제거.

## 검증
- MCP 서버 시작 확인 (크래시 없음)
- lint / tsc / build 통과