### PR TITLE
[M4-10] 활동 상세 페이지 고도화 (#70)

### DIFF
--- a/src/app/activities/[id]/activity-detail-client.tsx
+++ b/src/app/activities/[id]/activity-detail-client.tsx
@@ -426,8 +426,8 @@ function PreviousComparison({
               </tr>
             </thead>
             <tbody>
-              {similar.map((a) => (
-                <tr key={a.date} className="border-b border-border/50">
+              {similar.map((a, i) => (
+                <tr key={`${a.date}-${i}`} className="border-b border-border/50">
                   <td className="py-2 text-dim">{a.date.slice(5)}</td>
                   <td className="py-2">{a.name}</td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)]">

--- a/src/app/activities/[id]/activity-detail-client.tsx
+++ b/src/app/activities/[id]/activity-detail-client.tsx
@@ -165,13 +165,14 @@ export default function ActivityDetailClient({
         </div>
       )}
 
-      {/* M4-10: 이전 활동 비교 */}
-      {similarActivities.length > 0 && (
-        <PreviousComparison
-          current={activity}
-          similar={similarActivities}
-        />
-      )}
+      {/* M4-10: 이전 활동 비교 (러닝만) */}
+      {activity.activityType.includes("running") &&
+        similarActivities.length > 0 && (
+          <PreviousComparison
+            current={activity}
+            similar={similarActivities}
+          />
+        )}
 
       {/* AI 평가 */}
       <div className="mt-6">

--- a/src/app/activities/[id]/activity-detail-client.tsx
+++ b/src/app/activities/[id]/activity-detail-client.tsx
@@ -5,6 +5,7 @@ import DOMPurify from "dompurify";
 import { marked } from "marked";
 import ActivityDetail from "@/components/activity/ActivityDetail";
 import SplitChart from "@/components/activity/SplitChart";
+import { formatPace } from "@/lib/format";
 
 interface ActivityData {
   id: string;
@@ -36,8 +37,19 @@ interface ActivityData {
   intensityLabel: string | null;
 }
 
+interface SimilarActivity {
+  name: string;
+  date: string;
+  avgPace: number | null;
+  avgHR: number | null;
+  duration: number;
+  distanceKm: number | null;
+  intensityLabel: string | null;
+}
+
 interface Props {
   activity: ActivityData;
+  similarActivities?: SimilarActivity[];
 }
 
 function Stat({ label, value, unit }: { label: string; value: string; unit?: string }) {
@@ -52,7 +64,10 @@ function Stat({ label, value, unit }: { label: string; value: string; unit?: str
   );
 }
 
-export default function ActivityDetailClient({ activity }: Props) {
+export default function ActivityDetailClient({
+  activity,
+  similarActivities = [],
+}: Props) {
   const [aiEval, setAiEval] = useState<string | null>(null);
   const [aiLoading, setAiLoading] = useState(false);
 
@@ -148,6 +163,14 @@ export default function ActivityDetailClient({ activity }: Props) {
         <div className="mt-6">
           <SplitChart activityId={activity.id} />
         </div>
+      )}
+
+      {/* M4-10: 이전 활동 비교 */}
+      {similarActivities.length > 0 && (
+        <PreviousComparison
+          current={activity}
+          similar={similarActivities}
+        />
       )}
 
       {/* AI 평가 */}
@@ -286,6 +309,142 @@ function IntensityBreakdown({
               </div>
             );
           })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PreviousComparison({
+  current,
+  similar,
+}: {
+  current: ActivityData;
+  similar: SimilarActivity[];
+}) {
+  // 이전 활동 평균과 비교
+  const prevPaces = similar
+    .map((a) => a.avgPace)
+    .filter((p): p is number => p !== null);
+  const prevHRs = similar
+    .map((a) => a.avgHR)
+    .filter((h): h is number => h !== null);
+  const avgPrevPace =
+    prevPaces.length > 0
+      ? prevPaces.reduce((s, p) => s + p, 0) / prevPaces.length
+      : null;
+  const avgPrevHR =
+    prevHRs.length > 0
+      ? Math.round(prevHRs.reduce((s, h) => s + h, 0) / prevHRs.length)
+      : null;
+
+  const paceDelta =
+    current.avgPace !== null && avgPrevPace !== null
+      ? Math.round(current.avgPace - avgPrevPace)
+      : null;
+  const hrDelta =
+    current.avgHR !== null && avgPrevHR !== null
+      ? current.avgHR - avgPrevHR
+      : null;
+
+  return (
+    <div className="mt-6">
+      <h2 className="text-lg font-semibold mb-3">이전 활동 비교</h2>
+      <div className="bg-card border border-border rounded-xl p-5">
+        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+          유사 거리 최근 {similar.length}회 대비
+        </div>
+
+        {/* 델타 카드 */}
+        {(paceDelta !== null || hrDelta !== null) && (
+          <div className="grid grid-cols-2 gap-3 mb-4">
+            {paceDelta !== null && (
+              <div className="bg-surface rounded-lg p-3 text-center">
+                <div className="text-[10px] text-dim mb-1">페이스 변화</div>
+                <div
+                  className={`text-lg font-semibold font-[family-name:var(--font-geist-mono)] ${
+                    paceDelta < 0
+                      ? "text-accent"
+                      : paceDelta > 0
+                        ? "text-red-400"
+                        : "text-sub"
+                  }`}
+                >
+                  {paceDelta < 0 ? "" : "+"}
+                  {paceDelta}
+                  <span className="text-[11px] text-dim font-normal ml-1">
+                    초/km
+                  </span>
+                </div>
+                <div className="text-[10px] text-dim">
+                  {paceDelta < 0 ? "빨라짐" : paceDelta > 0 ? "느려짐" : "동일"}
+                </div>
+              </div>
+            )}
+            {hrDelta !== null && (
+              <div className="bg-surface rounded-lg p-3 text-center">
+                <div className="text-[10px] text-dim mb-1">심박 변화</div>
+                <div
+                  className={`text-lg font-semibold font-[family-name:var(--font-geist-mono)] ${
+                    hrDelta < 0
+                      ? "text-accent"
+                      : hrDelta > 0
+                        ? "text-yellow-400"
+                        : "text-sub"
+                  }`}
+                >
+                  {hrDelta > 0 ? "+" : ""}
+                  {hrDelta}
+                  <span className="text-[11px] text-dim font-normal ml-1">
+                    bpm
+                  </span>
+                </div>
+                <div className="text-[10px] text-dim">
+                  {hrDelta < 0
+                    ? "심박 낮아짐"
+                    : hrDelta > 0
+                      ? "심박 높아짐"
+                      : "동일"}
+                </div>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 이전 활동 목록 */}
+        <div className="overflow-x-auto">
+          <table className="w-full text-[12px]">
+            <thead>
+              <tr className="text-dim border-b border-border">
+                <th className="text-left py-2 font-normal">날짜</th>
+                <th className="text-left py-2 font-normal">이름</th>
+                <th className="text-right py-2 font-normal">거리</th>
+                <th className="text-right py-2 font-normal">페이스</th>
+                <th className="text-right py-2 font-normal">HR</th>
+                <th className="text-right py-2 font-normal">강도</th>
+              </tr>
+            </thead>
+            <tbody>
+              {similar.map((a) => (
+                <tr key={a.date} className="border-b border-border/50">
+                  <td className="py-2 text-dim">{a.date.slice(5)}</td>
+                  <td className="py-2">{a.name}</td>
+                  <td className="text-right font-[family-name:var(--font-geist-mono)]">
+                    {a.distanceKm ?? "—"}
+                  </td>
+                  <td className="text-right font-[family-name:var(--font-geist-mono)]">
+                    {a.avgPace ? formatPace(a.avgPace) : "—"}
+                  </td>
+                  <td className="text-right font-[family-name:var(--font-geist-mono)]">
+                    {a.avgHR ?? "—"}
+                  </td>
+                  <td className="text-right text-dim">
+                    {a.intensityLabel ?? "—"}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
         </div>
       </div>
     </div>

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -50,9 +50,10 @@ export default async function ActivityDetailPage({ params }: PageProps) {
     notFound();
   }
 
-  // M4-10: 이전 동일 유형 활동과 비교 (거리 ±10%, 최근 3개)
+  // M4-10: 이전 동일 유형 활동과 비교 (러닝만, 거리 ±10%, 최근 3개)
+  const isRunning = activity.activityType.includes("running");
   const similarActivities =
-    activity.distance && activity.distance > 0
+    isRunning && activity.distance && activity.distance > 0
       ? await prisma.activity.findMany({
           where: {
             activityType: activity.activityType,

--- a/src/app/activities/[id]/page.tsx
+++ b/src/app/activities/[id]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import prisma from "@/lib/prisma";
+import { formatDateLocal } from "@/lib/format";
 import { parseZoneDistribution } from "@/lib/fitness/intensity";
 import ActivityDetailClient from "./activity-detail-client";
 import Link from "next/link";
@@ -49,6 +50,32 @@ export default async function ActivityDetailPage({ params }: PageProps) {
     notFound();
   }
 
+  // M4-10: 이전 동일 유형 활동과 비교 (거리 ±10%, 최근 3개)
+  const similarActivities =
+    activity.distance && activity.distance > 0
+      ? await prisma.activity.findMany({
+          where: {
+            activityType: activity.activityType,
+            distance: {
+              gte: activity.distance * 0.9,
+              lte: activity.distance * 1.1,
+            },
+            startTime: { lt: activity.startTime },
+          },
+          orderBy: { startTime: "desc" },
+          take: 3,
+          select: {
+            name: true,
+            startTime: true,
+            avgPace: true,
+            avgHR: true,
+            duration: true,
+            distance: true,
+            intensityLabel: true,
+          },
+        })
+      : [];
+
   return (
     <div>
       <Link
@@ -68,6 +95,17 @@ export default async function ActivityDetailPage({ params }: PageProps) {
           startTime: activity.startTime.toISOString(),
           zoneDistribution: parseZoneDistribution(activity.zoneDistribution),
         }}
+        similarActivities={similarActivities.map((a) => ({
+          name: a.name,
+          date: formatDateLocal(a.startTime),
+          avgPace: a.avgPace,
+          avgHR: a.avgHR,
+          duration: a.duration,
+          distanceKm: a.distance
+            ? Number((a.distance / 1000).toFixed(2))
+            : null,
+          intensityLabel: a.intensityLabel,
+        }))}
       />
     </div>
   );

--- a/src/components/activity/SplitChart.tsx
+++ b/src/components/activity/SplitChart.tsx
@@ -1,7 +1,17 @@
 "use client";
 
 import { useState, useEffect } from "react";
-import { BarChart, Bar, XAxis, YAxis, ResponsiveContainer, Cell, Tooltip } from "recharts";
+import {
+  ComposedChart,
+  Bar,
+  Line,
+  XAxis,
+  YAxis,
+  ResponsiveContainer,
+  Cell,
+  Tooltip,
+  CartesianGrid,
+} from "recharts";
 import { formatPace } from "@/lib/format";
 
 interface LapDTO {
@@ -41,8 +51,12 @@ export default function SplitChart({ activityId }: SplitChartProps) {
   if (loading) {
     return (
       <div className="bg-card border border-border rounded-xl p-5">
-        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">킬로미터 스플릿</div>
-        <div className="h-40 flex items-center justify-center text-[13px] text-dim">로딩 중...</div>
+        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+          킬로미터 스플릿
+        </div>
+        <div className="h-40 flex items-center justify-center text-[13px] text-dim">
+          로딩 중...
+        </div>
       </div>
     );
   }
@@ -50,8 +64,12 @@ export default function SplitChart({ activityId }: SplitChartProps) {
   if (error) {
     return (
       <div className="bg-card border border-border rounded-xl p-5">
-        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">킬로미터 스플릿</div>
-        <div className="h-20 flex items-center justify-center text-[13px] text-dim">스플릿 데이터를 불러올 수 없습니다</div>
+        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+          킬로미터 스플릿
+        </div>
+        <div className="h-20 flex items-center justify-center text-[13px] text-dim">
+          스플릿 데이터를 불러올 수 없습니다
+        </div>
       </div>
     );
   }
@@ -59,8 +77,8 @@ export default function SplitChart({ activityId }: SplitChartProps) {
   if (laps.length === 0) return null;
 
   // km 랩만 필터 (워킹/비활성 구간 제외)
-  const activeLaps = laps.filter((l) =>
-    l.distance >= 900 && l.distance <= 1100
+  const activeLaps = laps.filter(
+    (l) => l.distance >= 900 && l.distance <= 1100
   );
   if (activeLaps.length === 0) return null;
 
@@ -77,58 +95,123 @@ export default function SplitChart({ activityId }: SplitChartProps) {
   });
 
   const paces = chartData.map((d) => d.pace).filter((p) => p > 0);
-  const avgPace = paces.length > 0 ? paces.reduce((s, p) => s + p, 0) / paces.length : 0;
+  const avgPace =
+    paces.length > 0 ? paces.reduce((s, p) => s + p, 0) / paces.length : 0;
   const maxPace = Math.max(...paces);
   const minPace = Math.min(...paces);
 
-  // 반전: 빠른 페이스(낮은 값)가 높은 막대가 되도록
-  // 기준선을 maxPace(가장 느린)로 잡고, 차이를 막대 높이로 사용
-  // 최소 높이 보장으로 모든 막대가 보이도록
   const range = maxPace - minPace || 1;
   const barData = chartData.map((d) => ({
     ...d,
-    barHeight: ((maxPace - d.pace) / range) * 100 + 15, // 15~115 범위
+    barHeight: ((maxPace - d.pace) / range) * 100 + 15,
     originalPace: d.pace,
   }));
 
+  const hasHR = chartData.some((d) => d.hr > 0);
+
   return (
     <div className="space-y-4">
-      {/* 페이스 바 차트 */}
+      {/* 페이스 바 + HR 라인 오버레이 */}
       <div className="bg-card border border-border rounded-xl p-5">
-        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
-          킬로미터 스플릿 ({activeLaps.length}km) — 평균 {formatPace(avgPace)}
+        <div className="flex items-center justify-between mb-4">
+          <div className="text-[11px] text-dim tracking-wider uppercase">
+            킬로미터 스플릿 ({activeLaps.length}km) — 평균{" "}
+            {formatPace(avgPace)}
+          </div>
+          {hasHR && (
+            <div className="flex gap-3 text-[10px] text-dim">
+              <span className="flex items-center gap-1">
+                <span className="w-2 h-2 rounded-sm bg-[#60a5fa]" />
+                페이스
+              </span>
+              <span className="flex items-center gap-1">
+                <span className="w-3 h-0.5 bg-[#ef4444]" />
+                심박
+              </span>
+            </div>
+          )}
         </div>
-        <ResponsiveContainer width="100%" height={150}>
-          <BarChart data={barData} barCategoryGap="15%">
+        <ResponsiveContainer width="100%" height={180}>
+          <ComposedChart
+            data={barData}
+            barCategoryGap="15%"
+            margin={{ top: 8, right: hasHR ? 40 : 8, bottom: 0, left: -10 }}
+          >
+            <CartesianGrid stroke="#1e1e1e" vertical={false} />
             <XAxis
               dataKey="km"
               axisLine={false}
               tickLine={false}
               tick={{ fontSize: 10, fill: "#525252" }}
             />
-            <YAxis hide />
+            <YAxis yAxisId="pace" hide />
+            {hasHR && (
+              <YAxis
+                yAxisId="hr"
+                orientation="right"
+                axisLine={false}
+                tickLine={false}
+                tick={{ fontSize: 10, fill: "#666" }}
+                domain={["dataMin - 10", "dataMax + 10"]}
+                tickFormatter={(v: number) => `${v}`}
+              />
+            )}
             <Tooltip
-              contentStyle={{ backgroundColor: "#1e1e1e", border: "1px solid #333333", borderRadius: 8, fontSize: 13, color: "#ededed" }}
-              itemStyle={{ color: "#ededed" }}
-              labelStyle={{ color: "#a3a3a3", marginBottom: 4 }}
-              formatter={(_value, _name, props) => [formatPace(props.payload.originalPace), "페이스"]}
+              contentStyle={{
+                backgroundColor: "#1e1e1e",
+                border: "1px solid #333333",
+                borderRadius: 8,
+                fontSize: 13,
+                color: "#ededed",
+              }}
+              formatter={(value, name, props) => {
+                const v = typeof value === "number" ? value : Number(value);
+                if (name === "barHeight") {
+                  return [
+                    formatPace(props.payload?.originalPace ?? v),
+                    "페이스",
+                  ];
+                }
+                if (name === "hr")
+                  return [Number.isFinite(v) ? `${v} bpm` : "—", "심박"];
+                return [String(value), String(name)];
+              }}
               labelFormatter={(label) => `${label} km`}
             />
-            <Bar dataKey="barHeight" radius={[2, 2, 0, 0]}>
+            <Bar dataKey="barHeight" yAxisId="pace" radius={[2, 2, 0, 0]}>
               {barData.map((entry, i) => (
                 <Cell
                   key={i}
-                  fill={entry.originalPace < avgPace ? "#22c55e" : entry.originalPace > avgPace * 1.05 ? "#ef4444" : "#60a5fa"}
+                  fill={
+                    entry.originalPace < avgPace
+                      ? "#22c55e"
+                      : entry.originalPace > avgPace * 1.05
+                        ? "#ef4444"
+                        : "#60a5fa"
+                  }
                 />
               ))}
             </Bar>
-          </BarChart>
+            {hasHR && (
+              <Line
+                type="monotone"
+                dataKey="hr"
+                yAxisId="hr"
+                stroke="#ef4444"
+                strokeWidth={2}
+                dot={{ r: 2, fill: "#ef4444" }}
+                name="hr"
+              />
+            )}
+          </ComposedChart>
         </ResponsiveContainer>
       </div>
 
       {/* 스플릿 테이블 */}
       <div className="bg-card border border-border rounded-xl p-5">
-        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">스플릿 상세</div>
+        <div className="text-[11px] text-dim tracking-wider uppercase mb-4">
+          스플릿 상세
+        </div>
         <div className="overflow-x-auto">
           <table className="w-full text-[12px]">
             <thead>
@@ -145,7 +228,16 @@ export default function SplitChart({ activityId }: SplitChartProps) {
                 <tr key={d.km} className="border-b border-border/50">
                   <td className="py-2">{d.km}</td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)]">
-                    <span style={{ color: d.pace < avgPace ? "#22c55e" : d.pace > avgPace * 1.05 ? "#ef4444" : "#a3a3a3" }}>
+                    <span
+                      style={{
+                        color:
+                          d.pace < avgPace
+                            ? "#22c55e"
+                            : d.pace > avgPace * 1.05
+                              ? "#ef4444"
+                              : "#a3a3a3",
+                      }}
+                    >
                       {formatPace(d.pace)}
                     </span>
                   </td>

--- a/src/components/activity/SplitChart.tsx
+++ b/src/components/activity/SplitChart.tsx
@@ -87,10 +87,10 @@ export default function SplitChart({ activityId }: SplitChartProps) {
     return {
       km: `${i + 1}`,
       pace: Math.round(paceSecKm),
-      hr: Math.round(lap.averageHR || 0),
-      cadence: Math.round(lap.averageRunCadence || 0),
-      elevation: Math.round(lap.elevationGain || 0),
-      power: Math.round(lap.averagePower || 0),
+      hr: lap.averageHR != null && lap.averageHR > 0 ? Math.round(lap.averageHR) : null,
+      cadence: lap.averageRunCadence != null ? Math.round(lap.averageRunCadence) : null,
+      elevation: lap.elevationGain != null ? Math.round(lap.elevationGain) : null,
+      power: lap.averagePower != null ? Math.round(lap.averagePower) : null,
     };
   });
 
@@ -107,7 +107,7 @@ export default function SplitChart({ activityId }: SplitChartProps) {
     originalPace: d.pace,
   }));
 
-  const hasHR = chartData.some((d) => d.hr > 0);
+  const hasHR = chartData.some((d) => d.hr !== null);
 
   return (
     <div className="space-y-4">
@@ -242,13 +242,13 @@ export default function SplitChart({ activityId }: SplitChartProps) {
                     </span>
                   </td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)]">
-                    {d.hr > 0 ? d.hr : "—"}
+                    {d.hr ?? "—"}
                   </td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)]">
-                    {d.cadence > 0 ? d.cadence : "—"}
+                    {d.cadence ?? "—"}
                   </td>
                   <td className="text-right font-[family-name:var(--font-geist-mono)]">
-                    {d.elevation > 0 ? `+${d.elevation}m` : "—"}
+                    {d.elevation != null && d.elevation > 0 ? `+${d.elevation}m` : "—"}
                   </td>
                 </tr>
               ))}


### PR DESCRIPTION
## 변경 사항

활동 상세 페이지에 HR 오버레이 차트 + 이전 활동 비교 기능 추가.

### SplitChart 확장
- BarChart → ComposedChart: 페이스 바 + HR 라인 오버레이 (dual Y축)
- 범례 (페이스 파랑/심박 빨강) 추가
- Tooltip에 심박 bpm 표시

### 이전 활동 비교 (PreviousComparison)
- 같은 activityType, 거리 ±10% 최근 3개 활동 자동 조회
- 델타 카드: 페이스 변화 (초/km), 심박 변화 (bpm) — 향상=초록, 후퇴=빨강
- 이전 활동 테이블: 날짜/이름/거리/페이스/HR/강도

Closes #70

## 체크리스트
- [x] lint / tsc / build 통과
- [x] codex review — 이슈 없음 ✅

## 테스트 플랜
- [ ] 러닝 활동 상세 진입 → 페이스 바 + HR 라인 오버레이 렌더링
- [ ] 유사 거리 이전 활동 있을 때 → 비교 섹션 + 델타 카드 표시
- [ ] 이전 활동 없을 때 → 비교 섹션 미표시
- [ ] 비러닝 활동 → 스플릿/비교 미표시