### PR TITLE
fix: 대시보드 KST 기준 + formatPace M:60 버그 수정

### DIFF
--- a/src/app/api/dashboard/route.ts
+++ b/src/app/api/dashboard/route.ts
@@ -1,24 +1,12 @@
 import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
-
-function todayLocal(): Date {
-  const d = new Date();
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
-function daysAgoLocal(n: number): Date {
-  const d = new Date();
-  d.setDate(d.getDate() - n);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
+import { todayKST, daysAgoKST } from "@/lib/garmin/utils";
 
 export async function GET() {
   try {
-    const today = todayLocal();
-    const yesterday = daysAgoLocal(1);
-    const weekAgo = daysAgoLocal(6);
+    const today = todayKST();
+    const yesterday = daysAgoKST(1);
+    const weekAgo = daysAgoKST(6);
 
     const [todaySummary, yesterdaySummary, todaySleep, yesterdaySleep] =
       await Promise.all([

--- a/src/components/dashboard/RecentActivities.tsx
+++ b/src/components/dashboard/RecentActivities.tsx
@@ -19,8 +19,9 @@ function formatDuration(seconds: number): string {
 }
 
 function formatPace(secPerKm: number): string {
-  const min = Math.floor(secPerKm / 60);
-  const sec = Math.round(secPerKm % 60);
+  const total = Math.round(secPerKm);
+  const min = Math.floor(total / 60);
+  const sec = total % 60;
   return `${min}'${sec.toString().padStart(2, "0")}"`;
 }
 

--- a/src/lib/format.ts
+++ b/src/lib/format.ts
@@ -18,10 +18,11 @@ export function formatDistance(meters: number): string {
   return (meters / 1000).toFixed(2);
 }
 
-/** sec/km → min'sec"/km */
+/** sec/km → min'sec"/km (반올림으로 60초 발생 방지) */
 export function formatPace(secPerKm: number): string {
-  const min = Math.floor(secPerKm / 60);
-  const sec = Math.round(secPerKm % 60);
+  const total = Math.round(secPerKm);
+  const min = Math.floor(total / 60);
+  const sec = total % 60;
   return `${min}'${sec.toString().padStart(2, "0")}"`;
 }
 

--- a/src/mcp/tools/fitness.ts
+++ b/src/mcp/tools/fitness.ts
@@ -57,7 +57,7 @@ export async function getActivities(args: { days?: number; type?: string }) {
             startTime: a.startTime.toISOString(),
             distanceKm: a.distance ? (a.distance / 1000).toFixed(2) : null,
             paceMinKm: a.avgPace
-              ? `${Math.floor(a.avgPace / 60)}'${Math.round(a.avgPace % 60).toString().padStart(2, "0")}"`
+              ? (() => { const t = Math.round(a.avgPace!); return `${Math.floor(t / 60)}'${(t % 60).toString().padStart(2, "0")}"`; })()
               : null,
             durationMin: Math.round(a.duration / 60),
           })),


### PR DESCRIPTION
릴리즈 PR #74 codex 리뷰에서 발견된 기존 코드 이슈 수정.

- **P1**: `/api/dashboard` 날짜 계산을 서버 로컬 → KST 유틸(todayKST/daysAgoKST)로 변경
- **P2**: `formatPace`에서 `Math.round(secPerKm % 60)` → `Math.round(total) → total % 60`으로 M:60 발생 방지. 3곳 통일 수정:
  - `src/lib/format.ts`
  - `src/components/dashboard/RecentActivities.tsx`
  - `src/mcp/tools/fitness.ts`