### PR TITLE
fix: 혈압 midpoint 통일 + 경고 최소 측정일 (#78 리뷰)

### DIFF
--- a/src/app/heart/page.tsx
+++ b/src/app/heart/page.tsx
@@ -103,13 +103,14 @@ export default async function HeartPage() {
     ])
   );
 
+  // 차트/상관관계: midpoint로 대표값 (독립 극값 조합 방지)
   const bpCorrelation = bpRecords.map((bp) => {
     const dateStr = formatDateLocal(bp.date);
     const daily = dailyMap.get(dateStr);
     return {
       date: dateStr,
-      systolic: bp.highSystolic,
-      diastolic: bp.highDiastolic,
+      systolic: Math.round((bp.highSystolic + bp.lowSystolic) / 2),
+      diastolic: Math.round((bp.highDiastolic + bp.lowDiastolic) / 2),
       sleepScore: sleepMap.get(dateStr) ?? null,
       avgStress: daily?.stress ?? null,
       bodyBattery: daily?.battery ?? null,
@@ -164,8 +165,8 @@ export default async function HeartPage() {
       latestBP={latestBPDisplay}
       bpTrend={bpRecords.map((r) => ({
         date: formatDateLocal(r.date),
-        systolic: r.highSystolic,
-        diastolic: r.highDiastolic,
+        systolic: Math.round((r.highSystolic + r.lowSystolic) / 2),
+        diastolic: Math.round((r.highDiastolic + r.lowDiastolic) / 2),
         pulse: r.avgPulse,
         category: r.category,
       }))}

--- a/src/mcp/tools/blood-pressure.ts
+++ b/src/mcp/tools/blood-pressure.ts
@@ -108,17 +108,19 @@ export async function getBloodPressure(args: { days?: number }) {
         )
       : null;
 
-  // 경고
+  // 경고 (최소 3일 측정 있어야 평균 기반 경고 발동 — 희소 데이터 과민 방지)
   const warnings: string[] = [];
-  if (avg7Systolic !== null && avg7Systolic >= 135) {
-    warnings.push(
-      `7일 평균 수축기 ${avg7Systolic}mmHg (midpoint 기준) — 상승 추세`
-    );
-  }
-  if (avg7Diastolic !== null && avg7Diastolic >= 85) {
-    warnings.push(
-      `7일 평균 이완기 ${avg7Diastolic}mmHg (midpoint 기준) — 상승 추세`
-    );
+  if (recent7.length >= 3) {
+    if (avg7Systolic !== null && avg7Systolic >= 135) {
+      warnings.push(
+        `7일 평균 수축기 ${avg7Systolic}mmHg (${recent7.length}일 측정) — 상승 추세`
+      );
+    }
+    if (avg7Diastolic !== null && avg7Diastolic >= 85) {
+      warnings.push(
+        `7일 평균 이완기 ${avg7Diastolic}mmHg (${recent7.length}일 측정) — 상승 추세`
+      );
+    }
   }
   // 3일 연속 STAGE_2_HIGH 체크 (달력일 기준, DST 안전)
   let consecutive2 = 0;


### PR DESCRIPTION
릴리즈 PR #78 codex 리뷰 P1/P2 수정.

- **P1**: bpTrend/bpCorrelation을 highSystolic → midpoint로 변경 (독립 극값 조합 방지)
- **P2**: 7일 평균 경고에 최소 3일 측정 조건 추가 (희소 데이터 과민 방지)