### PR TITLE
fix: 신규 데이터 타입 초기 히스토리 + MaxListeners 경고

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,12 @@
 export async function register() {
   // 서버 사이드에서만 실행 (Edge runtime 제외)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Garmin 싱크 시 다수의 병렬 HTTPS 요청이 동일 TLS 소켓에 error listener를
+    // 추가하면서 기본 한도 10을 넘어 MaxListenersExceededWarning 발생.
+    // 싱크 중 동시 요청 수 고려하여 여유 있게 상향.
+    const { EventEmitter } = await import("events");
+    EventEmitter.defaultMaxListeners = 30;
+
     const { startCronJobs } = await import("@/lib/cron");
     startCronJobs();
   }

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -29,6 +29,8 @@ export function startCronJobs() {
         const results = await syncAll({
           startDate: daysAgoKST(2),
           endDate: todayKST(),
+          // 신규 타입은 2일 윈도우 대신 365일 초기 히스토리 로드
+          bootstrapNewTypes: true,
         });
         const total = results.reduce((sum, r) => sum + r.synced, 0);
         const failed = results.filter((r) => r.error).length;

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -133,7 +133,13 @@ export async function syncAll(
   const results: SyncResult[] = [];
 
   for (const dataType of dataTypes) {
-    const startDate = options?.startDate ?? (await getStartDate(dataType));
+    // SyncMetadata가 없는 신규 데이터 타입은 explicit startDate를 무시하고
+    // 초기 히스토리 로드 (getStartDate가 INITIAL_HISTORY_DAYS 반환).
+    // 기존 타입은 explicit startDate(cron의 2일 윈도우 등) 우선.
+    const meta = await prisma.syncMetadata.findUnique({ where: { dataType } });
+    const startDate = meta
+      ? (options?.startDate ?? (await getStartDate(dataType)))
+      : await getStartDate(dataType);
 
     if (startDate > endDate) {
       console.log(`[${dataType}] 이미 최신 상태 (${formatDate(startDate)}까지 싱크 완료)`);

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -125,6 +125,12 @@ export async function syncAll(
     startDate?: Date;
     endDate?: Date;
     dataTypes?: DataType[];
+    /**
+     * true면 초기 싱크 안 된 타입에 대해 explicit startDate를 무시하고
+     * INITIAL_HISTORY_DAYS 강제 로드. cron이 2일 윈도우만 전달하는 상황에서
+     * 신규 타입(혈압 등)의 초기 히스토리를 놓치지 않도록. 기본 false.
+     */
+    bootstrapNewTypes?: boolean;
   }
 ): Promise<SyncResult[]> {
   // 기본 endDate: KST 기준 오늘
@@ -141,9 +147,21 @@ export async function syncAll(
     const hasSuccessfulSync = Boolean(
       meta && meta.lastSyncDate.getTime() > 0
     );
-    const startDate = hasSuccessfulSync
-      ? (options?.startDate ?? (await getStartDate(dataType)))
-      : daysAgo(INITIAL_HISTORY_DAYS);
+
+    let startDate: Date;
+    if (!hasSuccessfulSync && options?.bootstrapNewTypes) {
+      // 신규 타입 + bootstrap 모드 (cron): 365일 초기 로드
+      startDate = daysAgo(INITIAL_HISTORY_DAYS);
+    } else if (options?.startDate) {
+      // 명시 startDate 우선 (API 사용자 요청 등 의도된 범위 존중)
+      startDate = options.startDate;
+    } else if (hasSuccessfulSync) {
+      // 기본: 증분 싱크 (lastSyncDate + 1)
+      startDate = await getStartDate(dataType);
+    } else {
+      // 신규 타입 + 명시 없음: 365일
+      startDate = daysAgo(INITIAL_HISTORY_DAYS);
+    }
 
     if (startDate > endDate) {
       console.log(`[${dataType}] 이미 최신 상태 (${formatDate(startDate)}까지 싱크 완료)`);

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -133,12 +133,14 @@ export async function syncAll(
   const results: SyncResult[] = [];
 
   for (const dataType of dataTypes) {
-    // 한 번도 성공적으로 싱크된 적 없는 타입은 explicit startDate를 무시하고
-    // 직접 INITIAL_HISTORY_DAYS 만큼 거슬러 올라감.
-    // (markSyncing이 lastSyncDate=epoch 0으로 row를 미리 생성하므로
-    //  getStartDate가 1970-01-02를 반환할 위험 회피)
+    // 초기화 여부는 lastSyncDate로 판정:
+    // - markSyncing/markError가 생성한 row는 lastSyncDate=epoch(0)
+    // - updateSyncMetadata(성공 시)만 lastSyncDate를 실제 날짜로 설정
+    // syncCount는 record 수 기반이라 0-row 성공 시에도 0이므로 부적합.
     const meta = await prisma.syncMetadata.findUnique({ where: { dataType } });
-    const hasSuccessfulSync = Boolean(meta && meta.syncCount > 0);
+    const hasSuccessfulSync = Boolean(
+      meta && meta.lastSyncDate.getTime() > 0
+    );
     const startDate = hasSuccessfulSync
       ? (options?.startDate ?? (await getStartDate(dataType)))
       : daysAgo(INITIAL_HISTORY_DAYS);

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -134,13 +134,14 @@ export async function syncAll(
 
   for (const dataType of dataTypes) {
     // 한 번도 성공적으로 싱크된 적 없는 타입은 explicit startDate를 무시하고
-    // 초기 히스토리 로드 (getStartDate가 INITIAL_HISTORY_DAYS 반환).
-    // markSyncing이 row를 미리 생성하므로 meta 존재 여부가 아닌 syncCount 확인.
+    // 직접 INITIAL_HISTORY_DAYS 만큼 거슬러 올라감.
+    // (markSyncing이 lastSyncDate=epoch 0으로 row를 미리 생성하므로
+    //  getStartDate가 1970-01-02를 반환할 위험 회피)
     const meta = await prisma.syncMetadata.findUnique({ where: { dataType } });
     const hasSuccessfulSync = Boolean(meta && meta.syncCount > 0);
     const startDate = hasSuccessfulSync
       ? (options?.startDate ?? (await getStartDate(dataType)))
-      : await getStartDate(dataType);
+      : daysAgo(INITIAL_HISTORY_DAYS);
 
     if (startDate > endDate) {
       console.log(`[${dataType}] 이미 최신 상태 (${formatDate(startDate)}까지 싱크 완료)`);

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -133,11 +133,12 @@ export async function syncAll(
   const results: SyncResult[] = [];
 
   for (const dataType of dataTypes) {
-    // SyncMetadata가 없는 신규 데이터 타입은 explicit startDate를 무시하고
+    // 한 번도 성공적으로 싱크된 적 없는 타입은 explicit startDate를 무시하고
     // 초기 히스토리 로드 (getStartDate가 INITIAL_HISTORY_DAYS 반환).
-    // 기존 타입은 explicit startDate(cron의 2일 윈도우 등) 우선.
+    // markSyncing이 row를 미리 생성하므로 meta 존재 여부가 아닌 syncCount 확인.
     const meta = await prisma.syncMetadata.findUnique({ where: { dataType } });
-    const startDate = meta
+    const hasSuccessfulSync = Boolean(meta && meta.syncCount > 0);
+    const startDate = hasSuccessfulSync
       ? (options?.startDate ?? (await getStartDate(dataType)))
       : await getStartDate(dataType);
 


### PR DESCRIPTION
## 문제

1. **신규 데이터 타입 초기 히스토리 미로드**: cron이 `startDate: daysAgoKST(2)`를 명시적으로 전달하여, SyncMetadata가 없는 신규 타입(예: blood_pressure)도 2일만 싱크됨. 초기 365일 히스토리를 수동 트리거해야 했음.

2. **MaxListenersExceededWarning 다발**: `@flow-js/garmin-connect`가 axios로 다수의 HTTPS 요청을 보내면서 TLS 소켓에 error listener가 기본 한도(10)를 초과.
   ```
   (node:656637) MaxListenersExceededWarning: Possible EventEmitter memory leak detected.
   11 error listeners added to [TLSSocket]. MaxListeners is 10.
   ```

## 수정

- **`src/lib/garmin/sync.ts`**: SyncMetadata가 없는 신규 타입은 explicit startDate를 무시하고 `getStartDate(INITIAL_HISTORY_DAYS=365)`로 초기 로드. 기존 타입은 cron의 2일 윈도우 유지.
- **`src/instrumentation.ts`**: `EventEmitter.defaultMaxListeners = 30` 설정. 싱크 중 동시 요청 수를 고려한 안전한 상향.

## 영향
- 다음 릴리즈부터 신규 데이터 타입이 cron 첫 실행 시 자동으로 365일 히스토리 로드됨
- 로그에서 MaxListenersExceededWarning 제거