### PR TITLE
Hotfix v2.1.2: 신규 타입 초기 히스토리 + MaxListeners

### DIFF
--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,6 +1,12 @@
 export async function register() {
   // 서버 사이드에서만 실행 (Edge runtime 제외)
   if (process.env.NEXT_RUNTIME === "nodejs") {
+    // Garmin 싱크 시 다수의 병렬 HTTPS 요청이 동일 TLS 소켓에 error listener를
+    // 추가하면서 기본 한도 10을 넘어 MaxListenersExceededWarning 발생.
+    // 싱크 중 동시 요청 수 고려하여 여유 있게 상향.
+    const { EventEmitter } = await import("events");
+    EventEmitter.defaultMaxListeners = 30;
+
     const { startCronJobs } = await import("@/lib/cron");
     startCronJobs();
   }

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -29,6 +29,8 @@ export function startCronJobs() {
         const results = await syncAll({
           startDate: daysAgoKST(2),
           endDate: todayKST(),
+          // 신규 타입은 2일 윈도우 대신 365일 초기 히스토리 로드
+          bootstrapNewTypes: true,
         });
         const total = results.reduce((sum, r) => sum + r.synced, 0);
         const failed = results.filter((r) => r.error).length;

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -125,6 +125,12 @@ export async function syncAll(
     startDate?: Date;
     endDate?: Date;
     dataTypes?: DataType[];
+    /**
+     * true면 초기 싱크 안 된 타입에 대해 explicit startDate를 무시하고
+     * INITIAL_HISTORY_DAYS 강제 로드. cron이 2일 윈도우만 전달하는 상황에서
+     * 신규 타입(혈압 등)의 초기 히스토리를 놓치지 않도록. 기본 false.
+     */
+    bootstrapNewTypes?: boolean;
   }
 ): Promise<SyncResult[]> {
   // 기본 endDate: KST 기준 오늘
@@ -133,7 +139,29 @@ export async function syncAll(
   const results: SyncResult[] = [];
 
   for (const dataType of dataTypes) {
-    const startDate = options?.startDate ?? (await getStartDate(dataType));
+    // 초기화 여부는 lastSyncDate로 판정:
+    // - markSyncing/markError가 생성한 row는 lastSyncDate=epoch(0)
+    // - updateSyncMetadata(성공 시)만 lastSyncDate를 실제 날짜로 설정
+    // syncCount는 record 수 기반이라 0-row 성공 시에도 0이므로 부적합.
+    const meta = await prisma.syncMetadata.findUnique({ where: { dataType } });
+    const hasSuccessfulSync = Boolean(
+      meta && meta.lastSyncDate.getTime() > 0
+    );
+
+    let startDate: Date;
+    if (!hasSuccessfulSync && options?.bootstrapNewTypes) {
+      // 신규 타입 + bootstrap 모드 (cron): 365일 초기 로드
+      startDate = daysAgo(INITIAL_HISTORY_DAYS);
+    } else if (options?.startDate) {
+      // 명시 startDate 우선 (API 사용자 요청 등 의도된 범위 존중)
+      startDate = options.startDate;
+    } else if (hasSuccessfulSync) {
+      // 기본: 증분 싱크 (lastSyncDate + 1)
+      startDate = await getStartDate(dataType);
+    } else {
+      // 신규 타입 + 명시 없음: 365일
+      startDate = daysAgo(INITIAL_HISTORY_DAYS);
+    }
 
     if (startDate > endDate) {
       console.log(`[${dataType}] 이미 최신 상태 (${formatDate(startDate)}까지 싱크 완료)`);


### PR DESCRIPTION
## Hotfix v2.1.2

### 수정
- **신규 데이터 타입 초기 히스토리 자동 로드** — cron이 2일 윈도우만 전달하여 blood_pressure 등 신규 타입의 365일 초기 로드가 수동 트리거를 요구하던 문제. `syncAll`에 `bootstrapNewTypes` 옵션 추가하여 cron에서만 적용. `/api/sync`는 사용자 의도된 startDate 존중.
- **MaxListenersExceededWarning 해소** — `EventEmitter.defaultMaxListeners = 30`. Garmin 싱크 시 다수 병렬 HTTPS 요청이 동일 TLS 소켓에 error listener 추가하며 기본 한도 10 초과로 발생하던 경고 제거.

### 변경 파일
- `src/lib/garmin/sync.ts` (bootstrap 로직)
- `src/lib/cron.ts` (bootstrapNewTypes: true)
- `src/instrumentation.ts` (defaultMaxListeners)

### 배포
```bash
git pull && npm run build && pm2 restart all
```
(DB 마이그레이션 없음)