### PR TITLE
fix: 혈압 차트 툴팁 수축기 중복 표시 제거

### DIFF
--- a/src/app/heart/heart-client.tsx
+++ b/src/app/heart/heart-client.tsx
@@ -4,7 +4,6 @@ import { useState } from "react";
 import {
   ComposedChart,
   Line,
-  Area,
   XAxis,
   YAxis,
   ResponsiveContainer,
@@ -316,14 +315,6 @@ function BPTrendChart({ data }: { data: BPPoint[] }) {
               fontSize: 12,
               borderRadius: 6,
             }}
-          />
-          <Area
-            type="monotone"
-            dataKey="systolic"
-            stroke="none"
-            fill="#ef4444"
-            fillOpacity={0.1}
-            name="수축기"
           />
           <Line
             type="monotone"


### PR DESCRIPTION
## 문제

혈압 추세 차트에서 마우스 오버 시 툴팁에 '수축기'가 2번 반복 표시.

## 원인

`Area`와 `Line` 두 개가 동일한 `dataKey='systolic'`, `name='수축기'`로 렌더링되어 Recharts Tooltip이 둘 다 노출.

## 수정

장식용 `Area` 컴포넌트 제거. `Line`만 유지 (더 명확한 추세선).