### PR TITLE
[M2-8 후속2] KST instant 정확화 + 리포트 재생성 reportDate 유지 + 텔레그램 미수신 안전망 (#90)

### DIFF
--- a/docs/specs/m2-8-followup-kst-and-reports.md
+++ b/docs/specs/m2-8-followup-kst-and-reports.md
@@ -1,0 +1,180 @@
+# M2-8 후속2: KST instant 정확화 + 리포트 재생성 reportDate 유지 + 텔레그램 미수신 안전망
+
+## 배경
+
+M2-8(`docs/specs/m2-8-date-fix.md`) 및 후속(`docs/specs/m2-8-followup-endDate-yesterday.md`)에서 KST 정합성과 fetcher 가드를 부분 보강했다. 다음 세 이슈가 잇달아 드러나 한 묶음으로 정리한다.
+
+### (1) `utils.*KST` 함수가 진짜 KST midnight instant을 만들지 않음
+
+```ts
+// 현재 (문제)
+export function nowKST(): Date {
+  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+}
+```
+
+`toLocaleString("en-US", { timeZone: "Asia/Seoul" })` 결과는 KST 벽시계 시각의 문자열이지만, 그걸 `new Date(...)`로 다시 파싱하면 서버 로컬 타임존으로 해석된다. 즉 instant이 KST 벽시계와 timezone offset만큼 어긋난다 (UTC 서버에서 KST 9시 = UTC 0시인데 nowKST의 instant은 UTC 9시).
+
+서버가 KST(`Asia/Seoul`)인 환경에서는 우연히 정상 동작하나, fetcher의 미래 가드를 정확하게 짤 수 없고(M2-8 후속 PR #89의 P2 5건 누적 원인), 다른 타임존 환경으로 옮기면 즉시 회귀.
+
+### (2) 이브닝 리포트 재생성 시 `reportDate`가 다음날로 어긋남
+
+`src/lib/daily-report.ts`의 `generateReport()`는 매번 `kstDateStr()`로 현재 KST 날짜를 산출해 `reportDate`로 사용. 23:50 생성한 이브닝 리포트를 00:10에 재생성하면 새 record의 `reportDate`가 다음날이 되어 원본과 분리됨. 사용자 의도("기존 리포트를 갱신")와 어긋남.
+
+### (3) 텔레그램 모닝/이브닝 리포트 도착 안 함
+
+- `myfitness-bot` PM2 프로세스 정상 동작 확인됨.
+- `/report` 명령은 정상 작동 (DB 최신 record를 꺼내 응답).
+- cron 자동 전송만 도착 안 됨.
+
+가장 유력 원인 (코드상 식별 가능):
+- `generateReport` → `askAdvisor()` (`claude -p` CLI) 가 cron 시각에 throw → cron의 try-catch가 삼키고 끝 → record도 안 만들어지고 텔레그램 알림도 없음.
+- 사용자는 새벽/저녁에 무슨 일이 일어났는지 알 수 없음 (조용한 실패).
+
+## 요구사항
+
+### (1) KST 함수 재구현
+
+- [ ] `utils.ts`에 `ymdKST(d?: Date): string` 헬퍼 (Intl.DateTimeFormat "en-CA" 사용)
+- [ ] `todayKST()` / `yesterdayKST()` / `daysAgoKST(n)` 가 진짜 KST midnight instant Date 반환 (`new Date(\`${ymd}T00:00:00+09:00\`)`)
+- [ ] `nowKST()` 제거 또는 `new Date()` 별칭 (instant은 절대시각이므로 변환 불필요, KST 변환은 출력 시)
+- [ ] `todayKSTString()` 은 `ymdKST()` 사용
+- [ ] 사용처 영향 검증: cron, syncAll, daily-report.preSyncForReport, fetcher 가드
+
+### (2) 리포트 재생성 reportDate 유지
+
+- [ ] `generateReport(category, prompt, force=true)`에서 해당 카테고리의 가장 최근 record를 찾아 그 `reportDate`를 유지
+- [ ] 기존 record 없으면 현재 KST today로 폴백
+- [ ] delete + create 트랜잭션 유지
+
+### (3) 텔레그램 미수신 진단 + 안전망
+
+- [ ] `daily-report.generateReport`에서 단계별 로그 (`preSync 시작/완료`, `askAdvisor 시작/완료/길이`)
+- [ ] `askAdvisor` 결과가 falsy/empty면 명시적 throw → cron이 알아챔
+- [ ] `scheduler.startBotScheduler` cron try-catch에서 실패 시 `sendToAll`로 에러 메시지 전송 (조용한 실패 차단)
+- [ ] `sendToAll` 자체 호출 결과를 별도 로그로 가시화
+
+## 비목표
+
+- `claude -p` CLI 자체의 안정성 개선 (별도 이슈)
+- AI 리포트 콘텐츠 품질 개선
+- 모든 fetcher 가드 일괄 재정비 (utils 정확화 후 별도 이슈로 heart-rate 등 보강)
+
+## 기술 설계
+
+### KST 헬퍼
+
+```ts
+export function ymdKST(d: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(d);
+}
+
+export function todayKST(): Date {
+  return new Date(`${ymdKST()}T00:00:00+09:00`);
+}
+
+export function yesterdayKST(): Date {
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - 1);
+  return t;
+}
+
+export function daysAgoKST(n: number): Date {
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - n);
+  return t;
+}
+
+export function todayKSTString(): string {
+  return ymdKST();
+}
+```
+
+`setUTCDate`는 instant 단위 1일 감산이라 KST midnight 그대로 KST midnight (전날). DST 영향 없음 (KST는 DST 없음).
+
+### 리포트 재생성 reportDate
+
+```ts
+async function generateReport(category, prompt, force = false): Promise<string> {
+  const dateStr = todayKSTString();
+  
+  if (!force) {
+    const existing = await prisma.aIAdvice.findFirst({
+      where: { category, reportDate: dateStr },
+    });
+    if (existing) return existing.response;
+  }
+
+  // force=true: 기존 카테고리 최신 record의 reportDate 유지
+  const latest = force
+    ? await prisma.aIAdvice.findFirst({
+        where: { category },
+        orderBy: { createdAt: "desc" },
+      })
+    : null;
+  const targetDate = latest?.reportDate ?? dateStr;
+
+  console.log(`[${category}] preSync 시작`);
+  await preSyncForReport();
+  console.log(`[${category}] preSync 완료, askAdvisor 시작`);
+
+  const { result } = await askAdvisor(prompt);
+  console.log(`[${category}] askAdvisor 완료 (length=${result?.length ?? 0})`);
+
+  if (!result || result.trim().length === 0) {
+    throw new Error(`askAdvisor returned empty response for ${category}`);
+  }
+
+  // 트랜잭션: 같은 reportDate의 기존 record 삭제 + 새 create
+  await prisma.$transaction([
+    prisma.aIAdvice.deleteMany({ where: { category, reportDate: targetDate } }),
+    prisma.aIAdvice.create({
+      data: { category, reportDate: targetDate, prompt, response: result },
+    }),
+  ]);
+
+  return result;
+}
+```
+
+### cron 안전망
+
+```ts
+cron.schedule(morningSchedule, async () => {
+  console.log("[bot-cron] 모닝 리포트 시작");
+  try {
+    const report = await generateMorningReport();
+    const html = `☀️ <b>모닝 리포트</b>\n\n${mdToHtml(report)}`;
+    await sendToAll(bot, html);
+    console.log("[bot-cron] 모닝 리포트 전송 완료");
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error("[bot-cron] 모닝 리포트 에러:", msg);
+    // 조용한 실패 차단: 사용자에게 에러 알림
+    try {
+      await sendToAll(bot, `❌ 모닝 리포트 생성 실패: ${msg.slice(0, 500)}`);
+    } catch {
+      // 알림 자체도 실패 → 어쩔 수 없이 콘솔만
+    }
+  }
+}, { timezone: "Asia/Seoul" });
+```
+
+이브닝 리포트도 동일.
+
+## 테스트 계획
+
+1. `npm run lint && npx tsc --noEmit && npm run build` 통과
+2. KST 헬퍼 단위 테스트 (UTC/KST 환경 가정)
+   - `ymdKST(new Date('2026-04-28T14:59:59Z'))` === `'2026-04-28'` (KST 23:59)
+   - `ymdKST(new Date('2026-04-28T15:00:00Z'))` === `'2026-04-29'` (KST 00:00)
+3. 리포트 재생성 시나리오:
+   - 23:50 생성 → 00:10 재생성 → reportDate가 어제로 유지
+4. 봇 cron 직접 호출 시뮬레이션 (또는 다음 실제 cron run 관찰):
+   - askAdvisor 의도적 실패 시 텔레그램에 에러 알림 도착
+   - 정상 시 단계별 로그 PM2에 표시
+
+## 제외 사항
+
+- 미래 날짜 데이터 백필
+- 이전 리포트 record 중 reportDate가 어긋난 것 정리 (수동 SQL 별도)

--- a/docs/specs/m2-8-followup-kst-and-reports.md
+++ b/docs/specs/m2-8-followup-kst-and-reports.md
@@ -59,6 +59,11 @@ export function nowKST(): Date {
 - `claude -p` CLI 자체의 안정성 개선 (별도 이슈)
 - AI 리포트 콘텐츠 품질 개선
 - 모든 fetcher 가드 일괄 재정비 (utils 정확화 후 별도 이슈로 heart-rate 등 보강)
+- `asOfDate`를 리포트 생성 파이프라인 전체(preSync 범위, MCP tool query, 프롬프트)로 관통 — 본 PR은 가드(today/yesterday만 허용)로 차단만, 진짜 과거 컨텍스트 재생성은 별도 이슈
+- 잔여 KST 정합 회귀 (UTC 호스트 환경에서만 발현):
+  - `src/lib/fitness/calorie-balance.ts`의 `summaryKey`가 로컬 자정으로 만들어져 KST midnight instant로 저장된 `DailySummary.date`와 키 어긋남 가능성
+  - `src/lib/garmin/fetchers/sleep.ts`가 일부 위치에서 로컬 자정 저장
+  - 현재 서버는 KST이라 영향 없음, 별도 이슈로 분리
 
 ## 기술 설계
 

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -62,6 +62,16 @@ export async function POST(request: Request) {
     // 더 과거 record는 preSync/MCP/프롬프트가 모두 "오늘 기준"이라 과거 컨텍스트 보장 불가 → 차단.
     let reportDate: string | undefined;
     if (typeof body.reportDate === "string") {
+      // reportDate 명시는 force=true + morning/evening에서만 허용 (재생성 전용)
+      if (!force || (type !== "morning" && type !== "evening")) {
+        return NextResponse.json(
+          {
+            error:
+              "reportDate is only allowed with force=true and type in {morning, evening}",
+          },
+          { status: 400 }
+        );
+      }
       if (!/^\d{4}-\d{2}-\d{2}$/.test(body.reportDate)) {
         return NextResponse.json(
           { error: "reportDate must be YYYY-MM-DD" },

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -56,13 +56,18 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const type = body.type ?? "morning";
     const force = body.force === true;
+    // 자정 넘김 재생성 등 특정 날짜 record 갱신 시 명시. 미명시면 KST today.
+    const reportDate =
+      typeof body.reportDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.reportDate)
+        ? body.reportDate
+        : undefined;
 
     let result: string;
 
     if (type === "morning") {
-      result = await generateMorningReport(force);
+      result = await generateMorningReport(force, reportDate);
     } else if (type === "evening") {
-      result = await generateEveningReport(force);
+      result = await generateEveningReport(force, reportDate);
     } else if (type === "weekly") {
       result = await generateWeeklyReport();
     } else {

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { generateMorningReport, generateEveningReport } from "@/lib/daily-report";
 import { generateWeeklyReport } from "@/lib/weekly-report";
+import { todayKSTString, ymdKST, yesterdayKST } from "@/lib/garmin/utils";
 
 export async function GET(request: Request) {
   try {
@@ -57,10 +58,28 @@ export async function POST(request: Request) {
     const type = body.type ?? "morning";
     const force = body.force === true;
     // 자정 넘김 재생성 등 특정 날짜 record 갱신 시 명시. 미명시면 KST today.
-    const reportDate =
-      typeof body.reportDate === "string" && /^\d{4}-\d{2}-\d{2}$/.test(body.reportDate)
-        ? body.reportDate
-        : undefined;
+    // 데이터 무결성 가드: KST today/yesterday만 허용.
+    // 더 과거 record는 preSync/MCP/프롬프트가 모두 "오늘 기준"이라 과거 컨텍스트 보장 불가 → 차단.
+    let reportDate: string | undefined;
+    if (typeof body.reportDate === "string") {
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(body.reportDate)) {
+        return NextResponse.json(
+          { error: "reportDate must be YYYY-MM-DD" },
+          { status: 400 }
+        );
+      }
+      const today = todayKSTString();
+      const yesterday = ymdKST(yesterdayKST());
+      if (body.reportDate !== today && body.reportDate !== yesterday) {
+        return NextResponse.json(
+          {
+            error: `reportDate must be ${yesterday} or ${today} (자정 넘김 < 24h 재생성만 허용)`,
+          },
+          { status: 400 }
+        );
+      }
+      reportDate = body.reportDate;
+    }
 
     let result: string;
 

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -24,6 +24,16 @@ const TYPE_COLORS: Record<string, string> = {
   weekly_report: "#22c55e",
 };
 
+/** KST 기준 today/yesterday YYYY-MM-DD 반환. */
+function getKstTodayYesterday(): { today: string; yesterday: string } {
+  const fmt = new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" });
+  const today = fmt.format(new Date());
+  const yesterdayDate = new Date(`${today}T00:00:00+09:00`);
+  yesterdayDate.setUTCDate(yesterdayDate.getUTCDate() - 1);
+  const yesterday = fmt.format(yesterdayDate);
+  return { today, yesterday };
+}
+
 export default function ReportsPage() {
   const [reports, setReports] = useState<Report[]>([]);
   const [loading, setLoading] = useState(true);
@@ -86,48 +96,67 @@ export default function ReportsPage() {
       ) : reports.length === 0 ? (
         <div className="text-center py-12 text-dim text-[13px]">리포트 없음</div>
       ) : (
-        <div className="space-y-4">
-          {reports.map((r) => (
-            <div key={r.id} className="bg-card border border-border rounded-xl p-5">
-              <div className="flex items-center gap-2 mb-3">
-                <span
-                  className="w-2 h-2 rounded-full"
-                  style={{ backgroundColor: TYPE_COLORS[r.category] ?? "#737373" }}
-                />
-                <span
-                  className="text-[11px] tracking-wider uppercase"
-                  style={{ color: TYPE_COLORS[r.category] ?? "#737373" }}
+        (() => {
+          const { today, yesterday } = getKstTodayYesterday();
+          // 재생성 가능 카테고리: morning/evening만 (weekly는 자동 cron 외 재생성 안 함).
+          // 재생성 가능 record: reportDate가 KST today/yesterday일 때만 (과거 컨텍스트 보장 불가).
+          const canRegenerate = (r: Report) =>
+            (r.category === "morning_report" || r.category === "evening_report") &&
+            r.reportDate !== null &&
+            (r.reportDate === today || r.reportDate === yesterday);
+          return (
+            <div className="space-y-4">
+              {reports.map((r) => (
+                <div
+                  key={r.id}
+                  className="bg-card border border-border rounded-xl p-5"
                 >
-                  {TYPE_LABELS[r.category] ?? r.category}
-                </span>
-                <span className="text-[11px] text-dim">
-                  {r.reportDate ?? new Date(r.createdAt).toLocaleDateString("ko-KR")}
-                </span>
-                <button
-                  onClick={() =>
-                    generate(
-                      r.category.replace("_report", ""),
-                      true,
-                      r.reportDate ?? undefined
-                    )
-                  }
-                  disabled={generating !== null}
-                  className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
-                >
-                  재생성
-                </button>
-              </div>
-              <div
-                className="prose prose-invert prose-sm max-w-none"
-                dangerouslySetInnerHTML={{
-                  __html: DOMPurify.sanitize(
-                    marked.parse(r.response, { async: false }) as string
-                  ),
-                }}
-              />
+                  <div className="flex items-center gap-2 mb-3">
+                    <span
+                      className="w-2 h-2 rounded-full"
+                      style={{
+                        backgroundColor: TYPE_COLORS[r.category] ?? "#737373",
+                      }}
+                    />
+                    <span
+                      className="text-[11px] tracking-wider uppercase"
+                      style={{ color: TYPE_COLORS[r.category] ?? "#737373" }}
+                    >
+                      {TYPE_LABELS[r.category] ?? r.category}
+                    </span>
+                    <span className="text-[11px] text-dim">
+                      {r.reportDate ??
+                        new Date(r.createdAt).toLocaleDateString("ko-KR")}
+                    </span>
+                    {canRegenerate(r) && (
+                      <button
+                        onClick={() =>
+                          generate(
+                            r.category.replace("_report", ""),
+                            true,
+                            r.reportDate ?? undefined
+                          )
+                        }
+                        disabled={generating !== null}
+                        className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
+                      >
+                        재생성
+                      </button>
+                    )}
+                  </div>
+                  <div
+                    className="prose prose-invert prose-sm max-w-none"
+                    dangerouslySetInnerHTML={{
+                      __html: DOMPurify.sanitize(
+                        marked.parse(r.response, { async: false }) as string
+                      ),
+                    }}
+                  />
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
+          );
+        })()
       )}
     </div>
   );

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -36,13 +36,13 @@ export default function ReportsPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  async function generate(type: string, force = false) {
+  async function generate(type: string, force = false, reportDate?: string) {
     setGenerating(type);
     try {
       const res = await fetch("/api/reports", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type, force }),
+        body: JSON.stringify({ type, force, reportDate }),
       });
       const data = await res.json();
       if (data.result) {
@@ -104,7 +104,13 @@ export default function ReportsPage() {
                   {r.reportDate ?? new Date(r.createdAt).toLocaleDateString("ko-KR")}
                 </span>
                 <button
-                  onClick={() => generate(r.category.replace("_report", ""), true)}
+                  onClick={() =>
+                    generate(
+                      r.category.replace("_report", ""),
+                      true,
+                      r.reportDate ?? undefined
+                    )
+                  }
                   disabled={generating !== null}
                   className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
                 >

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
+import { todayKSTString, yesterdayKST, ymdKST } from "@/lib/garmin/utils";
 
 interface Report {
   id: string;
@@ -24,20 +25,18 @@ const TYPE_COLORS: Record<string, string> = {
   weekly_report: "#22c55e",
 };
 
-/** KST 기준 today/yesterday YYYY-MM-DD 반환. */
-function getKstTodayYesterday(): { today: string; yesterday: string } {
-  const fmt = new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" });
-  const today = fmt.format(new Date());
-  const yesterdayDate = new Date(`${today}T00:00:00+09:00`);
-  yesterdayDate.setUTCDate(yesterdayDate.getUTCDate() - 1);
-  const yesterday = fmt.format(yesterdayDate);
-  return { today, yesterday };
-}
-
 export default function ReportsPage() {
   const [reports, setReports] = useState<Report[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState<string | null>(null);
+  // 재생성 가능 record: reportDate가 KST today/yesterday일 때만
+  // (preSync/MCP/프롬프트가 모두 today 기준이라 과거 컨텍스트 보장 불가).
+  const today = todayKSTString();
+  const yesterday = ymdKST(yesterdayKST());
+  const canRegenerate = (r: Report) =>
+    (r.category === "morning_report" || r.category === "evening_report") &&
+    r.reportDate !== null &&
+    (r.reportDate === today || r.reportDate === yesterday);
 
   useEffect(() => {
     fetch("/api/reports?days=14")
@@ -96,67 +95,50 @@ export default function ReportsPage() {
       ) : reports.length === 0 ? (
         <div className="text-center py-12 text-dim text-[13px]">리포트 없음</div>
       ) : (
-        (() => {
-          const { today, yesterday } = getKstTodayYesterday();
-          // 재생성 가능 카테고리: morning/evening만 (weekly는 자동 cron 외 재생성 안 함).
-          // 재생성 가능 record: reportDate가 KST today/yesterday일 때만 (과거 컨텍스트 보장 불가).
-          const canRegenerate = (r: Report) =>
-            (r.category === "morning_report" || r.category === "evening_report") &&
-            r.reportDate !== null &&
-            (r.reportDate === today || r.reportDate === yesterday);
-          return (
-            <div className="space-y-4">
-              {reports.map((r) => (
-                <div
-                  key={r.id}
-                  className="bg-card border border-border rounded-xl p-5"
+        <div className="space-y-4">
+          {reports.map((r) => (
+            <div key={r.id} className="bg-card border border-border rounded-xl p-5">
+              <div className="flex items-center gap-2 mb-3">
+                <span
+                  className="w-2 h-2 rounded-full"
+                  style={{ backgroundColor: TYPE_COLORS[r.category] ?? "#737373" }}
+                />
+                <span
+                  className="text-[11px] tracking-wider uppercase"
+                  style={{ color: TYPE_COLORS[r.category] ?? "#737373" }}
                 >
-                  <div className="flex items-center gap-2 mb-3">
-                    <span
-                      className="w-2 h-2 rounded-full"
-                      style={{
-                        backgroundColor: TYPE_COLORS[r.category] ?? "#737373",
-                      }}
-                    />
-                    <span
-                      className="text-[11px] tracking-wider uppercase"
-                      style={{ color: TYPE_COLORS[r.category] ?? "#737373" }}
-                    >
-                      {TYPE_LABELS[r.category] ?? r.category}
-                    </span>
-                    <span className="text-[11px] text-dim">
-                      {r.reportDate ??
-                        new Date(r.createdAt).toLocaleDateString("ko-KR")}
-                    </span>
-                    {canRegenerate(r) && (
-                      <button
-                        onClick={() =>
-                          generate(
-                            r.category.replace("_report", ""),
-                            true,
-                            r.reportDate ?? undefined
-                          )
-                        }
-                        disabled={generating !== null}
-                        className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
-                      >
-                        재생성
-                      </button>
-                    )}
-                  </div>
-                  <div
-                    className="prose prose-invert prose-sm max-w-none"
-                    dangerouslySetInnerHTML={{
-                      __html: DOMPurify.sanitize(
-                        marked.parse(r.response, { async: false }) as string
-                      ),
-                    }}
-                  />
-                </div>
-              ))}
+                  {TYPE_LABELS[r.category] ?? r.category}
+                </span>
+                <span className="text-[11px] text-dim">
+                  {r.reportDate ?? new Date(r.createdAt).toLocaleDateString("ko-KR")}
+                </span>
+                {canRegenerate(r) && (
+                  <button
+                    onClick={() =>
+                      generate(
+                        r.category.replace("_report", ""),
+                        true,
+                        r.reportDate ?? undefined
+                      )
+                    }
+                    disabled={generating !== null}
+                    className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
+                  >
+                    재생성
+                  </button>
+                )}
+              </div>
+              <div
+                className="prose prose-invert prose-sm max-w-none"
+                dangerouslySetInnerHTML={{
+                  __html: DOMPurify.sanitize(
+                    marked.parse(r.response, { async: false }) as string
+                  ),
+                }}
+              />
             </div>
-          );
-        })()
+          ))}
+        </div>
       )}
     </div>
   );

--- a/src/bot/notifications/scheduler.ts
+++ b/src/bot/notifications/scheduler.ts
@@ -13,22 +13,35 @@ function getChatIds(): string[] {
     .filter(Boolean);
 }
 
-async function sendToAll(bot: Bot, text: string) {
-  for (const chatId of getChatIds()) {
+interface SendResult {
+  sent: number;
+  failed: number;
+  total: number;
+}
+
+async function sendToAll(bot: Bot, text: string): Promise<SendResult> {
+  const ids = getChatIds();
+  let sent = 0;
+  let failed = 0;
+  for (const chatId of ids) {
     try {
       const msg = text.length > MAX_MSG ? text.slice(0, MAX_MSG - 3) + "..." : text;
       await bot.api.sendMessage(chatId, msg, { parse_mode: "HTML" });
+      sent++;
     } catch (error) {
       console.error(`[bot] 메시지 전송 실패 (${chatId}):`, error);
-      // HTML 실패 시 plain text
+      // HTML 실패 시 plain text fallback
       try {
         const plain = text.replace(/<[^>]*>/g, "").slice(0, MAX_MSG);
         await bot.api.sendMessage(chatId, plain);
-      } catch {
-        // 무시
+        sent++;
+      } catch (plainErr) {
+        console.error(`[bot] plain text fallback도 실패 (${chatId}):`, plainErr);
+        failed++;
       }
     }
   }
+  return { sent, failed, total: ids.length };
 }
 
 /** 리포트 cron 콜백 공통 처리: 단계별 로그 + 실패 시 텔레그램 알림 (조용한 실패 차단) */
@@ -42,12 +55,27 @@ async function runReportCron(
   try {
     const report = await generate();
     const html = `${emoji} <b>${label}</b>\n\n${mdToHtml(report)}`;
-    await sendToAll(bot, html);
-    console.log(`[bot-cron] ${label} 전송 완료`);
+    const r = await sendToAll(bot, html);
+    if (r.total === 0) {
+      console.warn(
+        `[bot-cron] ${label} 전송 대상 없음 (TELEGRAM_ALLOWED_CHAT_IDS 미설정?)`
+      );
+    } else if (r.sent === 0) {
+      // 모든 채팅 전송 실패 → 조용한 실패 차단을 위해 명시적 throw
+      throw new Error(
+        `sendToAll: 모든 채팅 전송 실패 (failed=${r.failed}/total=${r.total})`
+      );
+    } else {
+      console.log(
+        `[bot-cron] ${label} 전송 완료 (sent=${r.sent}/total=${r.total}${
+          r.failed ? `, failed=${r.failed}` : ""
+        })`
+      );
+    }
   } catch (error) {
     const msg = error instanceof Error ? error.message : String(error);
     console.error(`[bot-cron] ${label} 에러:`, msg);
-    // 조용한 실패 차단: 사용자에게 에러 알림
+    // 조용한 실패 차단: 사용자에게 에러 알림 (sendToAll 자체도 실패할 수 있음)
     try {
       await sendToAll(bot, `❌ ${label} 생성 실패: ${msg.slice(0, 500)}`);
     } catch (notifyErr) {

--- a/src/bot/notifications/scheduler.ts
+++ b/src/bot/notifications/scheduler.ts
@@ -31,21 +31,37 @@ async function sendToAll(bot: Bot, text: string) {
   }
 }
 
+/** 리포트 cron 콜백 공통 처리: 단계별 로그 + 실패 시 텔레그램 알림 (조용한 실패 차단) */
+async function runReportCron(
+  bot: Bot,
+  label: string,
+  emoji: string,
+  generate: () => Promise<string>
+) {
+  console.log(`[bot-cron] ${label} 시작`);
+  try {
+    const report = await generate();
+    const html = `${emoji} <b>${label}</b>\n\n${mdToHtml(report)}`;
+    await sendToAll(bot, html);
+    console.log(`[bot-cron] ${label} 전송 완료`);
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[bot-cron] ${label} 에러:`, msg);
+    // 조용한 실패 차단: 사용자에게 에러 알림
+    try {
+      await sendToAll(bot, `❌ ${label} 생성 실패: ${msg.slice(0, 500)}`);
+    } catch (notifyErr) {
+      console.error(`[bot-cron] ${label} 에러 알림 전송도 실패:`, notifyErr);
+    }
+  }
+}
+
 export function startBotScheduler(bot: Bot) {
   // 모닝 리포트 (08:00 KST)
   const morningSchedule = process.env.MORNING_REPORT_CRON ?? "0 8 * * *";
   cron.schedule(
     morningSchedule,
-    async () => {
-      console.log("[bot-cron] 모닝 리포트 생성 + 전송");
-      try {
-        const report = await generateMorningReport();
-        const html = `☀️ <b>모닝 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 모닝 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "모닝 리포트", "☀️", () => generateMorningReport()),
     { timezone: "Asia/Seoul" }
   );
 
@@ -53,16 +69,7 @@ export function startBotScheduler(bot: Bot) {
   const eveningSchedule = process.env.EVENING_REPORT_CRON ?? "0 23 * * *";
   cron.schedule(
     eveningSchedule,
-    async () => {
-      console.log("[bot-cron] 이브닝 리포트 생성 + 전송");
-      try {
-        const report = await generateEveningReport();
-        const html = `🌙 <b>이브닝 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 이브닝 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "이브닝 리포트", "🌙", () => generateEveningReport()),
     { timezone: "Asia/Seoul" }
   );
 
@@ -70,18 +77,11 @@ export function startBotScheduler(bot: Bot) {
   const weeklySchedule = process.env.REPORT_CRON ?? "0 7 * * 1";
   cron.schedule(
     weeklySchedule,
-    async () => {
-      console.log("[bot-cron] 주간 리포트 생성 + 전송");
-      try {
-        const report = await generateWeeklyReport();
-        const html = `📊 <b>주간 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 주간 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "주간 리포트", "📊", () => generateWeeklyReport()),
     { timezone: "Asia/Seoul" }
   );
 
-  console.log("[bot-cron] 알림 스케줄 등록 완료 (모닝/이브닝/주간)");
+  console.log(
+    `[bot-cron] 알림 스케줄 등록 완료 (모닝=${morningSchedule}, 이브닝=${eveningSchedule}, 주간=${weeklySchedule}, TZ=Asia/Seoul)`
+  );
 }

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -65,33 +65,36 @@ async function generateReport(
     }
   }
 
-  // 리포트 전 데이터 최신화
+  // force=true: 카테고리의 가장 최근 record reportDate 유지 (자정 넘어 재생성 시 다음날로 어긋남 방지)
+  const latest = force
+    ? await prisma.aIAdvice.findFirst({
+        where: { category },
+        orderBy: { createdAt: "desc" },
+      })
+    : null;
+  const targetDate = latest?.reportDate ?? dateStr;
+
+  console.log(`[${category}] preSync 시작 (target=${targetDate})`);
   await preSyncForReport();
+  console.log(`[${category}] preSync 완료, askAdvisor 시작`);
 
   const { result } = await askAdvisor(prompt);
+  console.log(`[${category}] askAdvisor 완료 (length=${result?.length ?? 0})`);
 
-  try {
-    if (force) {
-      // 트랜잭션으로 삭제+생성을 원자적으로 (유실 방지)
-      await prisma.$transaction([
-        prisma.aIAdvice.deleteMany({ where: { category, reportDate: dateStr } }),
-        prisma.aIAdvice.create({
-          data: { category, reportDate: dateStr, prompt, response: result },
-        }),
-      ]);
-    } else {
-      await prisma.aIAdvice.create({
-        data: { category, reportDate: dateStr, prompt, response: result },
-      });
-    }
-    console.log(`[${category}] ${dateStr} ${force ? "재생성" : "생성"} 완료`);
-  } catch {
-    console.log(`[${category}] ${dateStr} 중복, 기존 리포트 사용`);
-    const fallback = await prisma.aIAdvice.findFirst({
-      where: { category, reportDate: dateStr },
-    });
-    if (fallback) return fallback.response;
+  // 조용한 실패 차단: 빈 응답이면 명시적 throw → 호출자(cron)가 알아챔
+  if (!result || result.trim().length === 0) {
+    throw new Error(`askAdvisor returned empty response for ${category}`);
   }
+
+  // 트랜잭션: 같은 reportDate의 기존 record 삭제 + 새 create.
+  // force=false 케이스에서도 동일 트랜잭션 사용 (race condition 시 중복 방지).
+  await prisma.$transaction([
+    prisma.aIAdvice.deleteMany({ where: { category, reportDate: targetDate } }),
+    prisma.aIAdvice.create({
+      data: { category, reportDate: targetDate, prompt, response: result },
+    }),
+  ]);
+  console.log(`[${category}] ${targetDate} ${force ? "재생성" : "생성"} 완료`);
 
   return result;
 }

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -50,29 +50,24 @@ async function preSyncForReport(): Promise<void> {
 async function generateReport(
   category: string,
   prompt: string,
-  force = false
+  force = false,
+  reportDate?: string
 ): Promise<string> {
   const dateStr = kstDateStr();
+  // reportDate 명시됐으면 그것 사용 (UI 재생성 버튼 등 자정 넘김 케이스).
+  // 미명시면 KST today.
+  const targetDate = reportDate ?? dateStr;
 
   // force가 아니면 기존 리포트 반환
   if (!force) {
     const existing = await prisma.aIAdvice.findFirst({
-      where: { category, reportDate: dateStr },
+      where: { category, reportDate: targetDate },
     });
     if (existing) {
-      console.log(`[${category}] ${dateStr} 이미 존재, 건너뜀`);
+      console.log(`[${category}] ${targetDate} 이미 존재, 건너뜀`);
       return existing.response;
     }
   }
-
-  // force=true: 카테고리의 가장 최근 record reportDate 유지 (자정 넘어 재생성 시 다음날로 어긋남 방지)
-  const latest = force
-    ? await prisma.aIAdvice.findFirst({
-        where: { category },
-        orderBy: { createdAt: "desc" },
-      })
-    : null;
-  const targetDate = latest?.reportDate ?? dateStr;
 
   console.log(`[${category}] preSync 시작 (target=${targetDate})`);
   await preSyncForReport();
@@ -99,10 +94,16 @@ async function generateReport(
   return result;
 }
 
-export async function generateMorningReport(force = false): Promise<string> {
-  return generateReport("morning_report", MORNING_PROMPT, force);
+export async function generateMorningReport(
+  force = false,
+  reportDate?: string
+): Promise<string> {
+  return generateReport("morning_report", MORNING_PROMPT, force, reportDate);
 }
 
-export async function generateEveningReport(force = false): Promise<string> {
-  return generateReport("evening_report", EVENING_PROMPT, force);
+export async function generateEveningReport(
+  force = false,
+  reportDate?: string
+): Promise<string> {
+  return generateReport("evening_report", EVENING_PROMPT, force, reportDate);
 }

--- a/src/lib/garmin/utils.ts
+++ b/src/lib/garmin/utils.ts
@@ -32,38 +32,45 @@ export function startOfDay(date: Date): Date {
 }
 
 // --- KST 기준 날짜 함수 ---
+//
+// 모든 함수는 진짜 KST midnight instant Date를 반환한다 (서버 타임존 무관).
+// 구현: Intl.DateTimeFormat("en-CA", timeZone:"Asia/Seoul")로 KST 벽시계 YYYY-MM-DD를
+// 추출 → "YYYY-MM-DDT00:00:00+09:00" ISO offset 문자열로 새 Date 생성.
+// setUTCDate는 instant 단위 1일 감산 → KST midnight instant 그대로 KST midnight (전날).
+// KST는 DST 없음.
 
-/** 현재 시간의 KST Date 객체 반환 */
-export function nowKST(): Date {
-  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+/** Date(또는 현재)를 KST 벽시계 기준 YYYY-MM-DD로 변환. 서버 타임존 무관. */
+export function ymdKST(d: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(d);
 }
 
-/** KST 기준 오늘 midnight */
+/** 현재 시각 (instant은 절대시각이라 타임존 변환 불필요) */
+export function nowKST(): Date {
+  return new Date();
+}
+
+/** KST 기준 오늘 midnight (정확한 instant) */
 export function todayKST(): Date {
-  const kst = nowKST();
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  return new Date(`${ymdKST()}T00:00:00+09:00`);
 }
 
 /** KST 기준 어제 midnight */
 export function yesterdayKST(): Date {
-  const kst = nowKST();
-  kst.setDate(kst.getDate() - 1);
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - 1);
+  return t;
 }
 
 /** KST 기준 N일 전 midnight */
 export function daysAgoKST(n: number): Date {
-  const kst = nowKST();
-  kst.setDate(kst.getDate() - n);
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - n);
+  return t;
 }
 
 /** KST 기준 오늘 날짜 문자열 YYYY-MM-DD */
 export function todayKSTString(): string {
-  return formatDate(todayKST());
+  return ymdKST();
 }
 
 // --- Legacy (하위 호환) ---

--- a/src/lib/garmin/utils.ts
+++ b/src/lib/garmin/utils.ts
@@ -2,33 +2,29 @@ export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** KST 기준 YYYY-MM-DD (서버 타임존 무관). */
 export function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  return ymdKST(date);
 }
 
+/** 입력 Date를 KST midnight instant로 정규화 (서버 타임존 무관). */
+export function startOfDay(date: Date): Date {
+  return new Date(`${ymdKST(date)}T00:00:00+09:00`);
+}
+
+/** [start, end] 구간을 KST 기준 1일씩 순회한 KST midnight instant Date 배열. */
 export function dateRange(startDate: Date, endDate: Date): Date[] {
   const dates: Date[] = [];
-  const current = new Date(startDate);
-  current.setHours(0, 0, 0, 0);
-
-  const end = new Date(endDate);
-  end.setHours(0, 0, 0, 0);
+  let current = startOfDay(startDate);
+  const end = startOfDay(endDate);
 
   while (current <= end) {
-    dates.push(new Date(current));
-    current.setDate(current.getDate() + 1);
+    dates.push(current);
+    // KST 기준 +1일 = UTC 기준 +24h (KST는 DST 없음)
+    current = new Date(current.getTime() + 24 * 60 * 60 * 1000);
   }
 
   return dates;
-}
-
-export function startOfDay(date: Date): Date {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d;
 }
 
 // --- KST 기준 날짜 함수 ---


### PR DESCRIPTION
## Summary

세 이슈를 한 PR로 묶어 처리.

### (1) `utils.*KST` 진짜 KST midnight instant
- `nowKST` → 그냥 `new Date()` (instant은 절대시각, 타임존 변환 출력 시)
- `todayKST/yesterdayKST/daysAgoKST` → `Intl.DateTimeFormat("en-CA", "Asia/Seoul")` + `T00:00:00+09:00` ISO offset 기반
- 다운스트림 `dateRange/formatDate/startOfDay`도 ymdKST 기반 KST midnight instant 처리로 통일 (UTC 호스트에서 fetcher가 잘못된 KST day로 호출하던 회귀 차단)

### (2) 리포트 재생성 시 `reportDate` 유지
- `generateReport(force, reportDate?)` 시그니처. 호출자가 명시 시 그것 사용, 아니면 KST today
- API: `reportDate`는 force=true + type∈{morning,evening}이고 KST today/yesterday일 때만 허용 (자정 넘김 < 24h)
- UI 재생성 버튼은 morning/evening 카테고리이고 reportDate가 today/yesterday일 때만 표시
- 트랜잭션으로 deleteMany + create (race 방지)

### (3) 텔레그램 미수신 안전망
- `daily-report.generateReport` 단계별 로그 (`preSync 시작/완료`, `askAdvisor 시작/완료/length`)
- `askAdvisor` 빈 응답이면 명시적 throw → cron이 알아챔
- `sendToAll` 이 `{sent, failed, total}` 반환, sent=0이면 `runReportCron`이 throw → 텔레그램 에러 알림 전송 (조용한 실패 차단)
- 스케줄 등록 시 cron 표현식 + TZ 한 줄 로깅

Closes #90

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과 (next + mcp + bot)
- [x] codex-cli 리뷰 P0/P1/P2 0건
- [ ] PM2 봇 재시작 후 다음 cron run에서 단계별 로그 + 도착 확인
- [ ] 23:50 생성 → 00:10 재생성 시 reportDate 유지 확인
- [ ] 7일 전 row 재생성 차단 (UI 버튼 미표시 + API 400) 확인

## 코드 리뷰 누적
| 라운드 | 도구 | 지적 | 조치 |
|---|---|---|---|
| 1 | GitHub codex | P1 #1 utils 다운스트림 KST 미정합 | dateRange/formatDate/startOfDay를 ymdKST 기반으로 |
| 1 | GitHub codex | P1 #2 force=true가 latest 자동 검색해 어제 record 덮어씀 | reportDate를 호출자가 명시 |
| 2 | GitHub codex | (P1 #1 캐시된 본문 재지적) + P2 임의 row 재생성 시 과거 컨텍스트 미보장 | reportDate를 today/yesterday로 가드 |
| 3 | codex-cli | P1 reportDate가 force=false에서도 허용 / sendToAll 결과 미검증 + P0 2건 | force=true 강제 + sendToAll 결과 검증 + UI 헬퍼 통합 |
| 4 | codex-cli | 0건 통과 | — |

## Spec
- `docs/specs/m2-8-followup-kst-and-reports.md`

## 별도 이슈 권장 (codex-cli 발견)
- `src/lib/fitness/calorie-balance.ts`의 `summaryKey` 로컬 자정 → KST midnight instant `DailySummary.date`와 키 어긋남 (UTC 호스트 환경)
- `src/lib/garmin/fetchers/sleep.ts` 일부 위치 로컬 자정 저장
- `asOfDate`를 리포트 생성 파이프라인 전체로 관통 (preSync/MCP/프롬프트 모두 과거 컨텍스트 보장)

현재 서버 KST이라 영향 없음.