### PR TITLE
[M2-8 후속3] calorie-balance / sleep / blood-pressure 잔여 KST 정합 (#92)

### DIFF
--- a/docs/specs/m2-8-followup-tz-cleanup.md
+++ b/docs/specs/m2-8-followup-tz-cleanup.md
@@ -1,0 +1,72 @@
+# M2-8 후속3: calorie-balance / sleep 잔여 KST 정합
+
+## 배경
+
+PR #91에서 `utils.startOfDay/dateRange/formatDate`를 KST-aware로 통일했으나, 두 곳에서 여전히 서버 로컬 midnight Date를 만들고 있어 다른 fetcher가 저장한 KST midnight UTC instant와 키 어긋남이 발생할 수 있다.
+
+### (1) `src/lib/garmin/fetchers/sleep.ts:31-32`
+```ts
+const [year, month, day] = calendarDate.split("-").map(Number);
+const dayDate = new Date(year, month - 1, day);
+dayDate.setHours(0, 0, 0, 0);
+```
+`new Date(year, month-1, day)`는 서버 로컬 midnight이라 서버가 KST일 때만 정합. `daily-summary` / `blood-pressure` / `body-composition` / `heart-rate`는 `startOfDay()`(KST-aware) 사용.
+
+### (2) `src/lib/fitness/calorie-balance.ts:34`
+```ts
+const summaryKey = new Date(y, m - 1, d, 0, 0, 0, 0);
+```
+같은 이유. 서버 KST 환경 가정으로 작성됐고 코멘트에도 명시. `DailySummary` 키가 이제 KST midnight UTC instant이므로 UTC 호스트에서 키 미스. `tx.dailySummary.findUnique({ where: { date: summaryKey } })` miss → 칼로리 밸런스 재계산 silent skip.
+
+### 영향
+- 서버 KST 환경(현재 운영)에서는 외형 동일 → 회귀 없음.
+- UTC 등 다른 타임존 호스트로 옮길 때만 발현.
+- 그러나 코드 일관성 + 이식성 차원에서 정리 필요.
+
+## 요구사항
+
+- [ ] `sleep.ts`: `calendarDate` string에서 KST midnight UTC instant Date 생성
+- [ ] `calorie-balance.ts`: `summaryKey`를 KST midnight UTC instant로 변경 + 코멘트 갱신
+- [ ] `npm run lint && npx tsc --noEmit && npm run build` 통과
+
+## 비목표
+
+- `asOfDate`를 리포트 생성 파이프라인 전체로 관통 (별도 큰 작업)
+- 기존 DB record 마이그레이션 (서버 KST 환경에선 instant 동일이라 영향 없음)
+
+## 기술 설계
+
+### sleep.ts
+
+```ts
+// calendarDate = "YYYY-MM-DD" → KST midnight UTC instant
+const dayDate = new Date(`${calendarDate}T00:00:00+09:00`);
+```
+
+또는 `startOfDay(new Date(year, month-1, day))` 사용 (다른 fetcher와 동일 패턴).
+ISO offset 직접 사용이 더 짧고 명확하므로 첫 번째 채택.
+
+### calorie-balance.ts
+
+```ts
+// 서버 TZ 무관 KST midnight UTC instant
+// DailySummary.date 저장 관례(=KST midnight instant, by utils.startOfDay)와 정합.
+const summaryKey = new Date(
+  `${parts.find(...year)}-${...month}-${...day}T00:00:00+09:00`
+);
+```
+
+`ymdKST(referenceDate)` 결과 string을 그대로 ISO offset에 붙이면 더 단순:
+
+```ts
+const ymd = ymdKST(referenceDate);
+const summaryKey = new Date(`${ymd}T00:00:00+09:00`);
+```
+
+`kstDayStart`/`kstDayEnd`는 기존 로직 유지(이미 KST midnight UTC instant).
+
+## 테스트 계획
+
+1. 정적 검사 통과
+2. 서버 KST 환경에서 외형 동작 동일 확인 (DailySummary 저장/조회 정상)
+3. UTC 시뮬레이션: `summaryKey`와 fetcher의 `dayDate`가 같은 instant인지 확인

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from "@/generated/prisma/client";
 import defaultPrisma from "@/lib/prisma";
+import { ymdKST } from "@/lib/garmin/utils";
 
 /** Serializable 트랜잭션 재시도 상수 */
 const MAX_RETRY = 3;
@@ -8,8 +9,8 @@ const RETRY_DELAY_MS = 50;
 /**
  * reference Date에서 다음 3가지 시각값을 산출:
  *
- * 1. `summaryKey` — DailySummary 조회용 key. sync 파이프라인의 저장 관례와 정합.
- *    `startOfDay(date)` = 서버 로컬 midnight of (KST wall-clock 날짜). 서버 TZ에 의존.
+ * 1. `summaryKey` — DailySummary 조회용 key. KST midnight UTC instant.
+ *    sync 파이프라인의 `utils.startOfDay`(KST-aware) 결과와 정합. 서버 TZ 무관.
  * 2. `kstDayStart` / `kstDayEnd` — FoodLog.date(실제 UTC instant) 집계용 경계.
  *    진짜 KST 00:00 UTC instant(= Date.UTC(Y,M,D) - 9h)로 서버 TZ와 무관하게 정확.
  */
@@ -20,20 +21,12 @@ function kstDayBoundary(referenceDate: Date): {
   kstDayStart: Date;
   kstDayEnd: Date;
 } {
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Seoul",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(referenceDate);
-  const y = Number(parts.find((p) => p.type === "year")!.value);
-  const m = Number(parts.find((p) => p.type === "month")!.value);
-  const d = Number(parts.find((p) => p.type === "day")!.value);
+  // KST 기준 YYYY-MM-DD에서 KST midnight UTC instant 생성
+  const ymd = ymdKST(referenceDate);
+  const summaryKey = new Date(`${ymd}T00:00:00+09:00`);
 
-  // DailySummary.date 저장 관례: 서버 로컬 midnight of KST 날짜
-  const summaryKey = new Date(y, m - 1, d, 0, 0, 0, 0);
-
-  // FoodLog 집계 경계: 진짜 KST 00:00 UTC instant
+  // FoodLog 집계 경계: 진짜 KST 00:00 UTC instant (summaryKey와 동일 instant이지만 명시 산출 유지)
+  const [y, m, d] = ymd.split("-").map(Number);
   const kstMidnightUTCms = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
   const kstDayStart = new Date(kstMidnightUTCms);
   const kstDayEnd = new Date(kstMidnightUTCms + 24 * 60 * 60 * 1000);

--- a/src/lib/garmin/fetchers/blood-pressure.ts
+++ b/src/lib/garmin/fetchers/blood-pressure.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { formatDate, startOfDay, todayKSTString, withRateLimit } from "../utils";
+import { formatDate, todayKSTString, withRateLimit } from "../utils";
 
 const BP_URL =
   "https://connectapi.garmin.com/bloodpressure-service/bloodpressure/range";
@@ -70,8 +70,8 @@ export async function syncBloodPressure(
       // 미래 날짜 방지 (타임존 스큐)
       if (summary.startDate > todayKSTString()) continue;
 
-      const [year, month, day] = summary.startDate.split("-").map(Number);
-      const dayDate = startOfDay(new Date(year, month - 1, day));
+      // KST midnight UTC instant (서버 타임존 무관)
+      const dayDate = new Date(`${summary.startDate}T00:00:00+09:00`);
 
       // 평균 맥박 계산
       const pulses = summary.measurements

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -27,9 +27,8 @@ export async function syncSleep(
       // Garmin calendarDate가 오늘(KST) 이후면 건너뛰기 (미래 날짜 방지)
       if (calendarDate > todayKSTString()) continue;
 
-      const [year, month, day] = calendarDate.split("-").map(Number);
-      const dayDate = new Date(year, month - 1, day);
-      dayDate.setHours(0, 0, 0, 0);
+      // KST midnight UTC instant (서버 타임존 무관, 다른 fetcher와 정합)
+      const dayDate = new Date(`${calendarDate}T00:00:00+09:00`);
 
       // 수면 점수 세부
       const sleepScoreDetails = dto.sleepScores


### PR DESCRIPTION
## Summary
PR #91에서 utils.startOfDay/dateRange/formatDate를 KST-aware로 통일했으나, 세 곳이 여전히 서버 로컬 midnight 사용 → UTC 등 다른 타임존 호스트에서 fetcher 간 키 미스 가능. 정리.

- `sleep.ts`: `calendarDate`에서 직접 `new Date(\`\${calendarDate}T00:00:00+09:00\`)`
- `blood-pressure.ts`: `summary.startDate`에서 동일 방식 (codex-cli 라운드에서 추가 발견)
- `calorie-balance.ts`: `summaryKey`를 `ymdKST + +09:00` ISO offset 기반으로

## 영향
서버 KST 환경에서는 외형 동작 동일 (회귀 없음). UTC 등 다른 타임존 호스트로 옮길 때만 발현되는 잠재 회귀를 일관성 차원에서 정리.

Closes #92

## Test plan
- [x] `npm run lint` 통과
- [x] `npx tsc --noEmit` 통과
- [x] `npm run build` 통과
- [x] codex-cli 리뷰 P0/P1/P2 0건

## 코드 리뷰 누적
| 라운드 | 도구 | 지적 | 조치 |
|---|---|---|---|
| 1 | codex-cli | P2 blood-pressure에 동일 패턴 누락 (Sydney 등 KST 앞선 TZ에서 하루 밀림) | string에서 직접 ISO offset로 변경 |
| 2 | codex-cli | 0건 통과 | ✅ |

## Spec
- `docs/specs/m2-8-followup-tz-cleanup.md`