### PR TITLE
Release v2.2.1: M2-8 후속 시리즈 (KST 정합 + 리포트 안정화)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -128,7 +128,8 @@
 - [x] 모닝/이브닝 리포트 전 데이터 싱크 수행
 - [x] 리포트 재생성 기능 (force 옵션, 재생성 버튼, 텔레그램 /report regenerate)
 - [x] body-composition fetcher 미래 instant 가드 (#88, PR #89)
-- 스펙: `docs/specs/m2-8-date-fix.md`, `docs/specs/m2-8-followup-endDate-yesterday.md`
+- [x] utils.*KST 진짜 KST midnight instant + 다운스트림 KST-aware + 리포트 재생성 reportDate 유지 + 텔레그램 미수신 안전망 (#90, PR #91)
+- 스펙: `docs/specs/m2-8-date-fix.md`, `docs/specs/m2-8-followup-endDate-yesterday.md`, `docs/specs/m2-8-followup-kst-and-reports.md`
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -213,6 +213,18 @@
 - [x] 이전 동일 유형 활동 비교 (페이스/HR 델타 카드 + 테이블)
 - [x] HR Zone 분포 스택바 + 강도 라벨 배지 (M4-5에서 구현)
 
+## M4-11: Garmin 프로필 자동 싱크 + 변경 이력 트래킹 ✅
+
+- [x] UserProfile에 source 필드 추가 (maxHRSource, lthrSource, restingHRBaseSource)
+- [x] heartRateZones + user-settings 양 endpoint 통합 싱크 (러닝 sport 우선)
+- [x] manual 값 보호 (source=manual이면 자동 갱신 차단)
+- [x] zonesRaw 신선도 체크 (stale Garmin zone 방지)
+- [x] MetricChange 모델 + recordMetricChange 헬퍼 (트랜잭션 원자성)
+- [x] MCP get_metric_history 도구 (필드/기간 필터, 변경 이력 조회)
+- [x] 프로필 페이지 source 배지 + lthrPace 표시
+- 효과: 가민 자동 측정값 반영 + 시간 경과별 피트니스 변화 추적
+- 스펙: `docs/specs/garmin-profile-sync.md`
+
 ---
 
 ### 권장 진행 순서

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -129,7 +129,8 @@
 - [x] 리포트 재생성 기능 (force 옵션, 재생성 버튼, 텔레그램 /report regenerate)
 - [x] body-composition fetcher 미래 instant 가드 (#88, PR #89)
 - [x] utils.*KST 진짜 KST midnight instant + 다운스트림 KST-aware + 리포트 재생성 reportDate 유지 + 텔레그램 미수신 안전망 (#90, PR #91)
-- 스펙: `docs/specs/m2-8-date-fix.md`, `docs/specs/m2-8-followup-endDate-yesterday.md`, `docs/specs/m2-8-followup-kst-and-reports.md`
+- [x] calorie-balance / sleep / blood-pressure 잔여 KST 정합 (#92, PR #93)
+- 스펙: `docs/specs/m2-8-date-fix.md`, `docs/specs/m2-8-followup-endDate-yesterday.md`, `docs/specs/m2-8-followup-kst-and-reports.md`, `docs/specs/m2-8-followup-tz-cleanup.md`
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -127,7 +127,8 @@
 - [x] garmin/utils.ts KST 날짜 유틸 통일 (nowKST, todayKST, yesterdayKST, daysAgoKST)
 - [x] 모닝/이브닝 리포트 전 데이터 싱크 수행
 - [x] 리포트 재생성 기능 (force 옵션, 재생성 버튼, 텔레그램 /report regenerate)
-- 스펙: `docs/specs/m2-8-date-fix.md`
+- [x] body-composition fetcher 미래 instant 가드 (#88, PR #89)
+- 스펙: `docs/specs/m2-8-date-fix.md`, `docs/specs/m2-8-followup-endDate-yesterday.md`
 
 ---
 

--- a/docs/specs/m2-8-followup-endDate-yesterday.md
+++ b/docs/specs/m2-8-followup-endDate-yesterday.md
@@ -1,0 +1,47 @@
+# M2-8 후속: body-composition fetcher 미래 instant 가드
+
+## 배경
+
+M2-8(`docs/specs/m2-8-date-fix.md`)에서 일부 fetcher(`daily-summary`, `sleep`, `blood-pressure`, `activities`)에 미래 날짜 가드를 도입했다.
+나머지 두 fetcher(`heart-rate`, `body-composition`) 중 `body-composition`은 Garmin이 epoch ms로 entry를 반환하므로 미래 instant이 들어올 가능성이 있어 가드를 추가한다.
+
+## 비목표
+
+`heart-rate` 가드는 추가하지 않는다. 이유:
+- `dateRange()`가 만든 dates는 호출자가 통제하는 endDate에서 파생되므로 호출자가 미래 endDate를 명시하지 않는 한 미래 호출이 발생하지 않음.
+- `todayKST()/daysAgoKST()`가 만든 Date는 진짜 KST midnight이 아니라 "서버 로컬로 해석된 KST 벽시계 시각"이라, instant/calendar 어느 비교든 서버 타임존에 따라 어긋날 수 있음 (codex 리뷰 P2 5건 누적).
+- 정확한 KST 정합성은 utils의 `*KST` 함수 재설계가 선행되어야 함 — 본 PR 범위 외.
+
+또한 cron / `syncAll` endDate 변경도 비목표:
+- **P1**: `syncAll` 기본 endDate 어제 변경 시 `scripts/sync-garmin.ts` 등 endDate 미명시 호출자 회귀
+- **P2**: cron 어제 변경 시 `body_composition`/`blood_pressure` 오늘 데이터가 자동 경로로 갱신 안 됨
+
+## 요구사항
+
+- [x] `src/lib/garmin/fetchers/body-composition.ts`: Garmin entry epoch ms가 미래 instant이면 skip
+- [x] `src/lib/cron.ts` / `src/lib/garmin/sync.ts` 의도 코멘트 정리
+
+## 기술 설계
+
+### body-composition 가드
+
+```ts
+const entryDate = new Date(entry.date);
+const dayDate = startOfDay(entryDate);
+
+// 미래 instant 방지 (서버 타임존 무관 절대 시각 비교)
+if (entryDate.getTime() > Date.now()) continue;
+```
+
+`entry.date`가 진짜 epoch ms라 instant 비교가 정확.
+
+## 테스트 계획
+
+1. `npm run lint && npx tsc --noEmit && npm run build` 통과
+2. cron / 수동 싱크 / `scripts/sync-garmin.ts` 회귀 없음 확인
+
+## 제외 사항
+
+- `heart-rate` fetcher 가드 (위 비목표 참조)
+- utils `*KST` 함수 재설계 (별도 이슈)
+- 미래 날짜 데이터 백필/정리

--- a/docs/specs/m2-8-followup-kst-and-reports.md
+++ b/docs/specs/m2-8-followup-kst-and-reports.md
@@ -1,0 +1,185 @@
+# M2-8 후속2: KST instant 정확화 + 리포트 재생성 reportDate 유지 + 텔레그램 미수신 안전망
+
+## 배경
+
+M2-8(`docs/specs/m2-8-date-fix.md`) 및 후속(`docs/specs/m2-8-followup-endDate-yesterday.md`)에서 KST 정합성과 fetcher 가드를 부분 보강했다. 다음 세 이슈가 잇달아 드러나 한 묶음으로 정리한다.
+
+### (1) `utils.*KST` 함수가 진짜 KST midnight instant을 만들지 않음
+
+```ts
+// 현재 (문제)
+export function nowKST(): Date {
+  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+}
+```
+
+`toLocaleString("en-US", { timeZone: "Asia/Seoul" })` 결과는 KST 벽시계 시각의 문자열이지만, 그걸 `new Date(...)`로 다시 파싱하면 서버 로컬 타임존으로 해석된다. 즉 instant이 KST 벽시계와 timezone offset만큼 어긋난다 (UTC 서버에서 KST 9시 = UTC 0시인데 nowKST의 instant은 UTC 9시).
+
+서버가 KST(`Asia/Seoul`)인 환경에서는 우연히 정상 동작하나, fetcher의 미래 가드를 정확하게 짤 수 없고(M2-8 후속 PR #89의 P2 5건 누적 원인), 다른 타임존 환경으로 옮기면 즉시 회귀.
+
+### (2) 이브닝 리포트 재생성 시 `reportDate`가 다음날로 어긋남
+
+`src/lib/daily-report.ts`의 `generateReport()`는 매번 `kstDateStr()`로 현재 KST 날짜를 산출해 `reportDate`로 사용. 23:50 생성한 이브닝 리포트를 00:10에 재생성하면 새 record의 `reportDate`가 다음날이 되어 원본과 분리됨. 사용자 의도("기존 리포트를 갱신")와 어긋남.
+
+### (3) 텔레그램 모닝/이브닝 리포트 도착 안 함
+
+- `myfitness-bot` PM2 프로세스 정상 동작 확인됨.
+- `/report` 명령은 정상 작동 (DB 최신 record를 꺼내 응답).
+- cron 자동 전송만 도착 안 됨.
+
+가장 유력 원인 (코드상 식별 가능):
+- `generateReport` → `askAdvisor()` (`claude -p` CLI) 가 cron 시각에 throw → cron의 try-catch가 삼키고 끝 → record도 안 만들어지고 텔레그램 알림도 없음.
+- 사용자는 새벽/저녁에 무슨 일이 일어났는지 알 수 없음 (조용한 실패).
+
+## 요구사항
+
+### (1) KST 함수 재구현
+
+- [ ] `utils.ts`에 `ymdKST(d?: Date): string` 헬퍼 (Intl.DateTimeFormat "en-CA" 사용)
+- [ ] `todayKST()` / `yesterdayKST()` / `daysAgoKST(n)` 가 진짜 KST midnight instant Date 반환 (`new Date(\`${ymd}T00:00:00+09:00\`)`)
+- [ ] `nowKST()` 제거 또는 `new Date()` 별칭 (instant은 절대시각이므로 변환 불필요, KST 변환은 출력 시)
+- [ ] `todayKSTString()` 은 `ymdKST()` 사용
+- [ ] 사용처 영향 검증: cron, syncAll, daily-report.preSyncForReport, fetcher 가드
+
+### (2) 리포트 재생성 reportDate 유지
+
+- [ ] `generateReport(category, prompt, force=true)`에서 해당 카테고리의 가장 최근 record를 찾아 그 `reportDate`를 유지
+- [ ] 기존 record 없으면 현재 KST today로 폴백
+- [ ] delete + create 트랜잭션 유지
+
+### (3) 텔레그램 미수신 진단 + 안전망
+
+- [ ] `daily-report.generateReport`에서 단계별 로그 (`preSync 시작/완료`, `askAdvisor 시작/완료/길이`)
+- [ ] `askAdvisor` 결과가 falsy/empty면 명시적 throw → cron이 알아챔
+- [ ] `scheduler.startBotScheduler` cron try-catch에서 실패 시 `sendToAll`로 에러 메시지 전송 (조용한 실패 차단)
+- [ ] `sendToAll` 자체 호출 결과를 별도 로그로 가시화
+
+## 비목표
+
+- `claude -p` CLI 자체의 안정성 개선 (별도 이슈)
+- AI 리포트 콘텐츠 품질 개선
+- 모든 fetcher 가드 일괄 재정비 (utils 정확화 후 별도 이슈로 heart-rate 등 보강)
+- `asOfDate`를 리포트 생성 파이프라인 전체(preSync 범위, MCP tool query, 프롬프트)로 관통 — 본 PR은 가드(today/yesterday만 허용)로 차단만, 진짜 과거 컨텍스트 재생성은 별도 이슈
+- 잔여 KST 정합 회귀 (UTC 호스트 환경에서만 발현):
+  - `src/lib/fitness/calorie-balance.ts`의 `summaryKey`가 로컬 자정으로 만들어져 KST midnight instant로 저장된 `DailySummary.date`와 키 어긋남 가능성
+  - `src/lib/garmin/fetchers/sleep.ts`가 일부 위치에서 로컬 자정 저장
+  - 현재 서버는 KST이라 영향 없음, 별도 이슈로 분리
+
+## 기술 설계
+
+### KST 헬퍼
+
+```ts
+export function ymdKST(d: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(d);
+}
+
+export function todayKST(): Date {
+  return new Date(`${ymdKST()}T00:00:00+09:00`);
+}
+
+export function yesterdayKST(): Date {
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - 1);
+  return t;
+}
+
+export function daysAgoKST(n: number): Date {
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - n);
+  return t;
+}
+
+export function todayKSTString(): string {
+  return ymdKST();
+}
+```
+
+`setUTCDate`는 instant 단위 1일 감산이라 KST midnight 그대로 KST midnight (전날). DST 영향 없음 (KST는 DST 없음).
+
+### 리포트 재생성 reportDate
+
+```ts
+async function generateReport(category, prompt, force = false): Promise<string> {
+  const dateStr = todayKSTString();
+  
+  if (!force) {
+    const existing = await prisma.aIAdvice.findFirst({
+      where: { category, reportDate: dateStr },
+    });
+    if (existing) return existing.response;
+  }
+
+  // force=true: 기존 카테고리 최신 record의 reportDate 유지
+  const latest = force
+    ? await prisma.aIAdvice.findFirst({
+        where: { category },
+        orderBy: { createdAt: "desc" },
+      })
+    : null;
+  const targetDate = latest?.reportDate ?? dateStr;
+
+  console.log(`[${category}] preSync 시작`);
+  await preSyncForReport();
+  console.log(`[${category}] preSync 완료, askAdvisor 시작`);
+
+  const { result } = await askAdvisor(prompt);
+  console.log(`[${category}] askAdvisor 완료 (length=${result?.length ?? 0})`);
+
+  if (!result || result.trim().length === 0) {
+    throw new Error(`askAdvisor returned empty response for ${category}`);
+  }
+
+  // 트랜잭션: 같은 reportDate의 기존 record 삭제 + 새 create
+  await prisma.$transaction([
+    prisma.aIAdvice.deleteMany({ where: { category, reportDate: targetDate } }),
+    prisma.aIAdvice.create({
+      data: { category, reportDate: targetDate, prompt, response: result },
+    }),
+  ]);
+
+  return result;
+}
+```
+
+### cron 안전망
+
+```ts
+cron.schedule(morningSchedule, async () => {
+  console.log("[bot-cron] 모닝 리포트 시작");
+  try {
+    const report = await generateMorningReport();
+    const html = `☀️ <b>모닝 리포트</b>\n\n${mdToHtml(report)}`;
+    await sendToAll(bot, html);
+    console.log("[bot-cron] 모닝 리포트 전송 완료");
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error("[bot-cron] 모닝 리포트 에러:", msg);
+    // 조용한 실패 차단: 사용자에게 에러 알림
+    try {
+      await sendToAll(bot, `❌ 모닝 리포트 생성 실패: ${msg.slice(0, 500)}`);
+    } catch {
+      // 알림 자체도 실패 → 어쩔 수 없이 콘솔만
+    }
+  }
+}, { timezone: "Asia/Seoul" });
+```
+
+이브닝 리포트도 동일.
+
+## 테스트 계획
+
+1. `npm run lint && npx tsc --noEmit && npm run build` 통과
+2. KST 헬퍼 단위 테스트 (UTC/KST 환경 가정)
+   - `ymdKST(new Date('2026-04-28T14:59:59Z'))` === `'2026-04-28'` (KST 23:59)
+   - `ymdKST(new Date('2026-04-28T15:00:00Z'))` === `'2026-04-29'` (KST 00:00)
+3. 리포트 재생성 시나리오:
+   - 23:50 생성 → 00:10 재생성 → reportDate가 어제로 유지
+4. 봇 cron 직접 호출 시뮬레이션 (또는 다음 실제 cron run 관찰):
+   - askAdvisor 의도적 실패 시 텔레그램에 에러 알림 도착
+   - 정상 시 단계별 로그 PM2에 표시
+
+## 제외 사항
+
+- 미래 날짜 데이터 백필
+- 이전 리포트 record 중 reportDate가 어긋난 것 정리 (수동 SQL 별도)

--- a/docs/specs/m2-8-followup-tz-cleanup.md
+++ b/docs/specs/m2-8-followup-tz-cleanup.md
@@ -1,0 +1,72 @@
+# M2-8 후속3: calorie-balance / sleep 잔여 KST 정합
+
+## 배경
+
+PR #91에서 `utils.startOfDay/dateRange/formatDate`를 KST-aware로 통일했으나, 두 곳에서 여전히 서버 로컬 midnight Date를 만들고 있어 다른 fetcher가 저장한 KST midnight UTC instant와 키 어긋남이 발생할 수 있다.
+
+### (1) `src/lib/garmin/fetchers/sleep.ts:31-32`
+```ts
+const [year, month, day] = calendarDate.split("-").map(Number);
+const dayDate = new Date(year, month - 1, day);
+dayDate.setHours(0, 0, 0, 0);
+```
+`new Date(year, month-1, day)`는 서버 로컬 midnight이라 서버가 KST일 때만 정합. `daily-summary` / `blood-pressure` / `body-composition` / `heart-rate`는 `startOfDay()`(KST-aware) 사용.
+
+### (2) `src/lib/fitness/calorie-balance.ts:34`
+```ts
+const summaryKey = new Date(y, m - 1, d, 0, 0, 0, 0);
+```
+같은 이유. 서버 KST 환경 가정으로 작성됐고 코멘트에도 명시. `DailySummary` 키가 이제 KST midnight UTC instant이므로 UTC 호스트에서 키 미스. `tx.dailySummary.findUnique({ where: { date: summaryKey } })` miss → 칼로리 밸런스 재계산 silent skip.
+
+### 영향
+- 서버 KST 환경(현재 운영)에서는 외형 동일 → 회귀 없음.
+- UTC 등 다른 타임존 호스트로 옮길 때만 발현.
+- 그러나 코드 일관성 + 이식성 차원에서 정리 필요.
+
+## 요구사항
+
+- [ ] `sleep.ts`: `calendarDate` string에서 KST midnight UTC instant Date 생성
+- [ ] `calorie-balance.ts`: `summaryKey`를 KST midnight UTC instant로 변경 + 코멘트 갱신
+- [ ] `npm run lint && npx tsc --noEmit && npm run build` 통과
+
+## 비목표
+
+- `asOfDate`를 리포트 생성 파이프라인 전체로 관통 (별도 큰 작업)
+- 기존 DB record 마이그레이션 (서버 KST 환경에선 instant 동일이라 영향 없음)
+
+## 기술 설계
+
+### sleep.ts
+
+```ts
+// calendarDate = "YYYY-MM-DD" → KST midnight UTC instant
+const dayDate = new Date(`${calendarDate}T00:00:00+09:00`);
+```
+
+또는 `startOfDay(new Date(year, month-1, day))` 사용 (다른 fetcher와 동일 패턴).
+ISO offset 직접 사용이 더 짧고 명확하므로 첫 번째 채택.
+
+### calorie-balance.ts
+
+```ts
+// 서버 TZ 무관 KST midnight UTC instant
+// DailySummary.date 저장 관례(=KST midnight instant, by utils.startOfDay)와 정합.
+const summaryKey = new Date(
+  `${parts.find(...year)}-${...month}-${...day}T00:00:00+09:00`
+);
+```
+
+`ymdKST(referenceDate)` 결과 string을 그대로 ISO offset에 붙이면 더 단순:
+
+```ts
+const ymd = ymdKST(referenceDate);
+const summaryKey = new Date(`${ymd}T00:00:00+09:00`);
+```
+
+`kstDayStart`/`kstDayEnd`는 기존 로직 유지(이미 KST midnight UTC instant).
+
+## 테스트 계획
+
+1. 정적 검사 통과
+2. 서버 KST 환경에서 외형 동작 동일 확인 (DailySummary 저장/조회 정상)
+3. UTC 시뮬레이션: `summaryKey`와 fetcher의 `dayDate`가 같은 instant인지 확인

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import prisma from "@/lib/prisma";
 import { generateMorningReport, generateEveningReport } from "@/lib/daily-report";
 import { generateWeeklyReport } from "@/lib/weekly-report";
+import { todayKSTString, ymdKST, yesterdayKST } from "@/lib/garmin/utils";
 
 export async function GET(request: Request) {
   try {
@@ -56,13 +57,46 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const type = body.type ?? "morning";
     const force = body.force === true;
+    // 자정 넘김 재생성 등 특정 날짜 record 갱신 시 명시. 미명시면 KST today.
+    // 데이터 무결성 가드: KST today/yesterday만 허용.
+    // 더 과거 record는 preSync/MCP/프롬프트가 모두 "오늘 기준"이라 과거 컨텍스트 보장 불가 → 차단.
+    let reportDate: string | undefined;
+    if (typeof body.reportDate === "string") {
+      // reportDate 명시는 force=true + morning/evening에서만 허용 (재생성 전용)
+      if (!force || (type !== "morning" && type !== "evening")) {
+        return NextResponse.json(
+          {
+            error:
+              "reportDate is only allowed with force=true and type in {morning, evening}",
+          },
+          { status: 400 }
+        );
+      }
+      if (!/^\d{4}-\d{2}-\d{2}$/.test(body.reportDate)) {
+        return NextResponse.json(
+          { error: "reportDate must be YYYY-MM-DD" },
+          { status: 400 }
+        );
+      }
+      const today = todayKSTString();
+      const yesterday = ymdKST(yesterdayKST());
+      if (body.reportDate !== today && body.reportDate !== yesterday) {
+        return NextResponse.json(
+          {
+            error: `reportDate must be ${yesterday} or ${today} (자정 넘김 < 24h 재생성만 허용)`,
+          },
+          { status: 400 }
+        );
+      }
+      reportDate = body.reportDate;
+    }
 
     let result: string;
 
     if (type === "morning") {
-      result = await generateMorningReport(force);
+      result = await generateMorningReport(force, reportDate);
     } else if (type === "evening") {
-      result = await generateEveningReport(force);
+      result = await generateEveningReport(force, reportDate);
     } else if (type === "weekly") {
       result = await generateWeeklyReport();
     } else {

--- a/src/app/reports/page.tsx
+++ b/src/app/reports/page.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from "react";
 import DOMPurify from "dompurify";
 import { marked } from "marked";
+import { todayKSTString, yesterdayKST, ymdKST } from "@/lib/garmin/utils";
 
 interface Report {
   id: string;
@@ -28,6 +29,14 @@ export default function ReportsPage() {
   const [reports, setReports] = useState<Report[]>([]);
   const [loading, setLoading] = useState(true);
   const [generating, setGenerating] = useState<string | null>(null);
+  // 재생성 가능 record: reportDate가 KST today/yesterday일 때만
+  // (preSync/MCP/프롬프트가 모두 today 기준이라 과거 컨텍스트 보장 불가).
+  const today = todayKSTString();
+  const yesterday = ymdKST(yesterdayKST());
+  const canRegenerate = (r: Report) =>
+    (r.category === "morning_report" || r.category === "evening_report") &&
+    r.reportDate !== null &&
+    (r.reportDate === today || r.reportDate === yesterday);
 
   useEffect(() => {
     fetch("/api/reports?days=14")
@@ -36,13 +45,13 @@ export default function ReportsPage() {
       .finally(() => setLoading(false));
   }, []);
 
-  async function generate(type: string, force = false) {
+  async function generate(type: string, force = false, reportDate?: string) {
     setGenerating(type);
     try {
       const res = await fetch("/api/reports", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ type, force }),
+        body: JSON.stringify({ type, force, reportDate }),
       });
       const data = await res.json();
       if (data.result) {
@@ -103,13 +112,21 @@ export default function ReportsPage() {
                 <span className="text-[11px] text-dim">
                   {r.reportDate ?? new Date(r.createdAt).toLocaleDateString("ko-KR")}
                 </span>
-                <button
-                  onClick={() => generate(r.category.replace("_report", ""), true)}
-                  disabled={generating !== null}
-                  className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
-                >
-                  재생성
-                </button>
+                {canRegenerate(r) && (
+                  <button
+                    onClick={() =>
+                      generate(
+                        r.category.replace("_report", ""),
+                        true,
+                        r.reportDate ?? undefined
+                      )
+                    }
+                    disabled={generating !== null}
+                    className="ml-auto text-[10px] text-dim hover:text-sub transition-colors disabled:opacity-50"
+                  >
+                    재생성
+                  </button>
+                )}
               </div>
               <div
                 className="prose prose-invert prose-sm max-w-none"

--- a/src/bot/notifications/scheduler.ts
+++ b/src/bot/notifications/scheduler.ts
@@ -13,20 +13,73 @@ function getChatIds(): string[] {
     .filter(Boolean);
 }
 
-async function sendToAll(bot: Bot, text: string) {
-  for (const chatId of getChatIds()) {
+interface SendResult {
+  sent: number;
+  failed: number;
+  total: number;
+}
+
+async function sendToAll(bot: Bot, text: string): Promise<SendResult> {
+  const ids = getChatIds();
+  let sent = 0;
+  let failed = 0;
+  for (const chatId of ids) {
     try {
       const msg = text.length > MAX_MSG ? text.slice(0, MAX_MSG - 3) + "..." : text;
       await bot.api.sendMessage(chatId, msg, { parse_mode: "HTML" });
+      sent++;
     } catch (error) {
       console.error(`[bot] 메시지 전송 실패 (${chatId}):`, error);
-      // HTML 실패 시 plain text
+      // HTML 실패 시 plain text fallback
       try {
         const plain = text.replace(/<[^>]*>/g, "").slice(0, MAX_MSG);
         await bot.api.sendMessage(chatId, plain);
-      } catch {
-        // 무시
+        sent++;
+      } catch (plainErr) {
+        console.error(`[bot] plain text fallback도 실패 (${chatId}):`, plainErr);
+        failed++;
       }
+    }
+  }
+  return { sent, failed, total: ids.length };
+}
+
+/** 리포트 cron 콜백 공통 처리: 단계별 로그 + 실패 시 텔레그램 알림 (조용한 실패 차단) */
+async function runReportCron(
+  bot: Bot,
+  label: string,
+  emoji: string,
+  generate: () => Promise<string>
+) {
+  console.log(`[bot-cron] ${label} 시작`);
+  try {
+    const report = await generate();
+    const html = `${emoji} <b>${label}</b>\n\n${mdToHtml(report)}`;
+    const r = await sendToAll(bot, html);
+    if (r.total === 0) {
+      console.warn(
+        `[bot-cron] ${label} 전송 대상 없음 (TELEGRAM_ALLOWED_CHAT_IDS 미설정?)`
+      );
+    } else if (r.sent === 0) {
+      // 모든 채팅 전송 실패 → 조용한 실패 차단을 위해 명시적 throw
+      throw new Error(
+        `sendToAll: 모든 채팅 전송 실패 (failed=${r.failed}/total=${r.total})`
+      );
+    } else {
+      console.log(
+        `[bot-cron] ${label} 전송 완료 (sent=${r.sent}/total=${r.total}${
+          r.failed ? `, failed=${r.failed}` : ""
+        })`
+      );
+    }
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    console.error(`[bot-cron] ${label} 에러:`, msg);
+    // 조용한 실패 차단: 사용자에게 에러 알림 (sendToAll 자체도 실패할 수 있음)
+    try {
+      await sendToAll(bot, `❌ ${label} 생성 실패: ${msg.slice(0, 500)}`);
+    } catch (notifyErr) {
+      console.error(`[bot-cron] ${label} 에러 알림 전송도 실패:`, notifyErr);
     }
   }
 }
@@ -36,16 +89,7 @@ export function startBotScheduler(bot: Bot) {
   const morningSchedule = process.env.MORNING_REPORT_CRON ?? "0 8 * * *";
   cron.schedule(
     morningSchedule,
-    async () => {
-      console.log("[bot-cron] 모닝 리포트 생성 + 전송");
-      try {
-        const report = await generateMorningReport();
-        const html = `☀️ <b>모닝 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 모닝 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "모닝 리포트", "☀️", () => generateMorningReport()),
     { timezone: "Asia/Seoul" }
   );
 
@@ -53,16 +97,7 @@ export function startBotScheduler(bot: Bot) {
   const eveningSchedule = process.env.EVENING_REPORT_CRON ?? "0 23 * * *";
   cron.schedule(
     eveningSchedule,
-    async () => {
-      console.log("[bot-cron] 이브닝 리포트 생성 + 전송");
-      try {
-        const report = await generateEveningReport();
-        const html = `🌙 <b>이브닝 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 이브닝 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "이브닝 리포트", "🌙", () => generateEveningReport()),
     { timezone: "Asia/Seoul" }
   );
 
@@ -70,18 +105,11 @@ export function startBotScheduler(bot: Bot) {
   const weeklySchedule = process.env.REPORT_CRON ?? "0 7 * * 1";
   cron.schedule(
     weeklySchedule,
-    async () => {
-      console.log("[bot-cron] 주간 리포트 생성 + 전송");
-      try {
-        const report = await generateWeeklyReport();
-        const html = `📊 <b>주간 리포트</b>\n\n${mdToHtml(report)}`;
-        await sendToAll(bot, html);
-      } catch (error) {
-        console.error("[bot-cron] 주간 리포트 에러:", error);
-      }
-    },
+    () => runReportCron(bot, "주간 리포트", "📊", () => generateWeeklyReport()),
     { timezone: "Asia/Seoul" }
   );
 
-  console.log("[bot-cron] 알림 스케줄 등록 완료 (모닝/이브닝/주간)");
+  console.log(
+    `[bot-cron] 알림 스케줄 등록 완료 (모닝=${morningSchedule}, 이브닝=${eveningSchedule}, 주간=${weeklySchedule}, TZ=Asia/Seoul)`
+  );
 }

--- a/src/lib/cron.ts
+++ b/src/lib/cron.ts
@@ -24,7 +24,8 @@ export function startCronJobs() {
       console.log("[cron] Garmin 자동 싱크 시작");
 
       try {
-        // KST 기준 2일 전 ~ 어제 (당일 데이터 제외 → 미래 날짜 방지)
+        // KST 기준 2일 전 ~ 오늘. 오늘 부분 데이터(체중/혈압/걸음 등)도
+        // 자동 갱신 대상에 포함. 미래 날짜는 각 fetcher의 calendarDate 가드가 차단.
         const { daysAgoKST, todayKST } = await import("@/lib/garmin/utils");
         const results = await syncAll({
           startDate: daysAgoKST(2),

--- a/src/lib/daily-report.ts
+++ b/src/lib/daily-report.ts
@@ -50,56 +50,60 @@ async function preSyncForReport(): Promise<void> {
 async function generateReport(
   category: string,
   prompt: string,
-  force = false
+  force = false,
+  reportDate?: string
 ): Promise<string> {
   const dateStr = kstDateStr();
+  // reportDate 명시됐으면 그것 사용 (UI 재생성 버튼 등 자정 넘김 케이스).
+  // 미명시면 KST today.
+  const targetDate = reportDate ?? dateStr;
 
   // force가 아니면 기존 리포트 반환
   if (!force) {
     const existing = await prisma.aIAdvice.findFirst({
-      where: { category, reportDate: dateStr },
+      where: { category, reportDate: targetDate },
     });
     if (existing) {
-      console.log(`[${category}] ${dateStr} 이미 존재, 건너뜀`);
+      console.log(`[${category}] ${targetDate} 이미 존재, 건너뜀`);
       return existing.response;
     }
   }
 
-  // 리포트 전 데이터 최신화
+  console.log(`[${category}] preSync 시작 (target=${targetDate})`);
   await preSyncForReport();
+  console.log(`[${category}] preSync 완료, askAdvisor 시작`);
 
   const { result } = await askAdvisor(prompt);
+  console.log(`[${category}] askAdvisor 완료 (length=${result?.length ?? 0})`);
 
-  try {
-    if (force) {
-      // 트랜잭션으로 삭제+생성을 원자적으로 (유실 방지)
-      await prisma.$transaction([
-        prisma.aIAdvice.deleteMany({ where: { category, reportDate: dateStr } }),
-        prisma.aIAdvice.create({
-          data: { category, reportDate: dateStr, prompt, response: result },
-        }),
-      ]);
-    } else {
-      await prisma.aIAdvice.create({
-        data: { category, reportDate: dateStr, prompt, response: result },
-      });
-    }
-    console.log(`[${category}] ${dateStr} ${force ? "재생성" : "생성"} 완료`);
-  } catch {
-    console.log(`[${category}] ${dateStr} 중복, 기존 리포트 사용`);
-    const fallback = await prisma.aIAdvice.findFirst({
-      where: { category, reportDate: dateStr },
-    });
-    if (fallback) return fallback.response;
+  // 조용한 실패 차단: 빈 응답이면 명시적 throw → 호출자(cron)가 알아챔
+  if (!result || result.trim().length === 0) {
+    throw new Error(`askAdvisor returned empty response for ${category}`);
   }
+
+  // 트랜잭션: 같은 reportDate의 기존 record 삭제 + 새 create.
+  // force=false 케이스에서도 동일 트랜잭션 사용 (race condition 시 중복 방지).
+  await prisma.$transaction([
+    prisma.aIAdvice.deleteMany({ where: { category, reportDate: targetDate } }),
+    prisma.aIAdvice.create({
+      data: { category, reportDate: targetDate, prompt, response: result },
+    }),
+  ]);
+  console.log(`[${category}] ${targetDate} ${force ? "재생성" : "생성"} 완료`);
 
   return result;
 }
 
-export async function generateMorningReport(force = false): Promise<string> {
-  return generateReport("morning_report", MORNING_PROMPT, force);
+export async function generateMorningReport(
+  force = false,
+  reportDate?: string
+): Promise<string> {
+  return generateReport("morning_report", MORNING_PROMPT, force, reportDate);
 }
 
-export async function generateEveningReport(force = false): Promise<string> {
-  return generateReport("evening_report", EVENING_PROMPT, force);
+export async function generateEveningReport(
+  force = false,
+  reportDate?: string
+): Promise<string> {
+  return generateReport("evening_report", EVENING_PROMPT, force, reportDate);
 }

--- a/src/lib/fitness/calorie-balance.ts
+++ b/src/lib/fitness/calorie-balance.ts
@@ -1,5 +1,6 @@
 import type { Prisma, PrismaClient } from "@/generated/prisma/client";
 import defaultPrisma from "@/lib/prisma";
+import { ymdKST } from "@/lib/garmin/utils";
 
 /** Serializable 트랜잭션 재시도 상수 */
 const MAX_RETRY = 3;
@@ -8,8 +9,8 @@ const RETRY_DELAY_MS = 50;
 /**
  * reference Date에서 다음 3가지 시각값을 산출:
  *
- * 1. `summaryKey` — DailySummary 조회용 key. sync 파이프라인의 저장 관례와 정합.
- *    `startOfDay(date)` = 서버 로컬 midnight of (KST wall-clock 날짜). 서버 TZ에 의존.
+ * 1. `summaryKey` — DailySummary 조회용 key. KST midnight UTC instant.
+ *    sync 파이프라인의 `utils.startOfDay`(KST-aware) 결과와 정합. 서버 TZ 무관.
  * 2. `kstDayStart` / `kstDayEnd` — FoodLog.date(실제 UTC instant) 집계용 경계.
  *    진짜 KST 00:00 UTC instant(= Date.UTC(Y,M,D) - 9h)로 서버 TZ와 무관하게 정확.
  */
@@ -20,20 +21,12 @@ function kstDayBoundary(referenceDate: Date): {
   kstDayStart: Date;
   kstDayEnd: Date;
 } {
-  const parts = new Intl.DateTimeFormat("en-CA", {
-    timeZone: "Asia/Seoul",
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit",
-  }).formatToParts(referenceDate);
-  const y = Number(parts.find((p) => p.type === "year")!.value);
-  const m = Number(parts.find((p) => p.type === "month")!.value);
-  const d = Number(parts.find((p) => p.type === "day")!.value);
+  // KST 기준 YYYY-MM-DD에서 KST midnight UTC instant 생성
+  const ymd = ymdKST(referenceDate);
+  const summaryKey = new Date(`${ymd}T00:00:00+09:00`);
 
-  // DailySummary.date 저장 관례: 서버 로컬 midnight of KST 날짜
-  const summaryKey = new Date(y, m - 1, d, 0, 0, 0, 0);
-
-  // FoodLog 집계 경계: 진짜 KST 00:00 UTC instant
+  // FoodLog 집계 경계: 진짜 KST 00:00 UTC instant (summaryKey와 동일 instant이지만 명시 산출 유지)
+  const [y, m, d] = ymd.split("-").map(Number);
   const kstMidnightUTCms = Date.UTC(y, m - 1, d) - KST_OFFSET_MS;
   const kstDayStart = new Date(kstMidnightUTCms);
   const kstDayEnd = new Date(kstMidnightUTCms + 24 * 60 * 60 * 1000);

--- a/src/lib/garmin/fetchers/blood-pressure.ts
+++ b/src/lib/garmin/fetchers/blood-pressure.ts
@@ -1,7 +1,7 @@
 import type { GarminConnect } from "@flow-js/garmin-connect";
 import type { Prisma } from "@/generated/prisma/client";
 import prisma from "@/lib/prisma";
-import { formatDate, startOfDay, todayKSTString, withRateLimit } from "../utils";
+import { formatDate, todayKSTString, withRateLimit } from "../utils";
 
 const BP_URL =
   "https://connectapi.garmin.com/bloodpressure-service/bloodpressure/range";
@@ -70,8 +70,8 @@ export async function syncBloodPressure(
       // 미래 날짜 방지 (타임존 스큐)
       if (summary.startDate > todayKSTString()) continue;
 
-      const [year, month, day] = summary.startDate.split("-").map(Number);
-      const dayDate = startOfDay(new Date(year, month - 1, day));
+      // KST midnight UTC instant (서버 타임존 무관)
+      const dayDate = new Date(`${summary.startDate}T00:00:00+09:00`);
 
       // 평균 맥박 계산
       const pulses = summary.measurements

--- a/src/lib/garmin/fetchers/body-composition.ts
+++ b/src/lib/garmin/fetchers/body-composition.ts
@@ -49,6 +49,10 @@ export async function syncBodyComposition(
     try {
       const entryDate = new Date(entry.date);
       const dayDate = startOfDay(entryDate);
+
+      // 미래 instant 방지 (서버 타임존 무관 절대 시각 비교)
+      if (entryDate.getTime() > Date.now()) continue;
+
       const weight = gramToKg(entry.weight);
 
       if (weight === null) continue;

--- a/src/lib/garmin/fetchers/sleep.ts
+++ b/src/lib/garmin/fetchers/sleep.ts
@@ -27,9 +27,8 @@ export async function syncSleep(
       // Garmin calendarDate가 오늘(KST) 이후면 건너뛰기 (미래 날짜 방지)
       if (calendarDate > todayKSTString()) continue;
 
-      const [year, month, day] = calendarDate.split("-").map(Number);
-      const dayDate = new Date(year, month - 1, day);
-      dayDate.setHours(0, 0, 0, 0);
+      // KST midnight UTC instant (서버 타임존 무관, 다른 fetcher와 정합)
+      const dayDate = new Date(`${calendarDate}T00:00:00+09:00`);
 
       // 수면 점수 세부
       const sleepScoreDetails = dto.sleepScores

--- a/src/lib/garmin/sync.ts
+++ b/src/lib/garmin/sync.ts
@@ -137,7 +137,7 @@ export async function syncAll(
     bootstrapNewTypes?: boolean;
   }
 ): Promise<SyncResult[]> {
-  // 기본 endDate: KST 기준 오늘
+  // 기본 endDate: KST 기준 오늘. 미래 날짜는 각 fetcher의 calendarDate 가드가 차단.
   const endDate = options?.endDate ?? todayKST();
   const dataTypes = options?.dataTypes ?? SYNC_ORDER;
   const results: SyncResult[] = [];

--- a/src/lib/garmin/utils.ts
+++ b/src/lib/garmin/utils.ts
@@ -2,68 +2,71 @@ export function delay(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** KST 기준 YYYY-MM-DD (서버 타임존 무관). */
 export function formatDate(date: Date): string {
-  const y = date.getFullYear();
-  const m = String(date.getMonth() + 1).padStart(2, "0");
-  const d = String(date.getDate()).padStart(2, "0");
-  return `${y}-${m}-${d}`;
+  return ymdKST(date);
 }
 
+/** 입력 Date를 KST midnight instant로 정규화 (서버 타임존 무관). */
+export function startOfDay(date: Date): Date {
+  return new Date(`${ymdKST(date)}T00:00:00+09:00`);
+}
+
+/** [start, end] 구간을 KST 기준 1일씩 순회한 KST midnight instant Date 배열. */
 export function dateRange(startDate: Date, endDate: Date): Date[] {
   const dates: Date[] = [];
-  const current = new Date(startDate);
-  current.setHours(0, 0, 0, 0);
-
-  const end = new Date(endDate);
-  end.setHours(0, 0, 0, 0);
+  let current = startOfDay(startDate);
+  const end = startOfDay(endDate);
 
   while (current <= end) {
-    dates.push(new Date(current));
-    current.setDate(current.getDate() + 1);
+    dates.push(current);
+    // KST 기준 +1일 = UTC 기준 +24h (KST는 DST 없음)
+    current = new Date(current.getTime() + 24 * 60 * 60 * 1000);
   }
 
   return dates;
 }
 
-export function startOfDay(date: Date): Date {
-  const d = new Date(date);
-  d.setHours(0, 0, 0, 0);
-  return d;
-}
-
 // --- KST 기준 날짜 함수 ---
+//
+// 모든 함수는 진짜 KST midnight instant Date를 반환한다 (서버 타임존 무관).
+// 구현: Intl.DateTimeFormat("en-CA", timeZone:"Asia/Seoul")로 KST 벽시계 YYYY-MM-DD를
+// 추출 → "YYYY-MM-DDT00:00:00+09:00" ISO offset 문자열로 새 Date 생성.
+// setUTCDate는 instant 단위 1일 감산 → KST midnight instant 그대로 KST midnight (전날).
+// KST는 DST 없음.
 
-/** 현재 시간의 KST Date 객체 반환 */
-export function nowKST(): Date {
-  return new Date(new Date().toLocaleString("en-US", { timeZone: "Asia/Seoul" }));
+/** Date(또는 현재)를 KST 벽시계 기준 YYYY-MM-DD로 변환. 서버 타임존 무관. */
+export function ymdKST(d: Date = new Date()): string {
+  return new Intl.DateTimeFormat("en-CA", { timeZone: "Asia/Seoul" }).format(d);
 }
 
-/** KST 기준 오늘 midnight */
+/** 현재 시각 (instant은 절대시각이라 타임존 변환 불필요) */
+export function nowKST(): Date {
+  return new Date();
+}
+
+/** KST 기준 오늘 midnight (정확한 instant) */
 export function todayKST(): Date {
-  const kst = nowKST();
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  return new Date(`${ymdKST()}T00:00:00+09:00`);
 }
 
 /** KST 기준 어제 midnight */
 export function yesterdayKST(): Date {
-  const kst = nowKST();
-  kst.setDate(kst.getDate() - 1);
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - 1);
+  return t;
 }
 
 /** KST 기준 N일 전 midnight */
 export function daysAgoKST(n: number): Date {
-  const kst = nowKST();
-  kst.setDate(kst.getDate() - n);
-  kst.setHours(0, 0, 0, 0);
-  return kst;
+  const t = todayKST();
+  t.setUTCDate(t.getUTCDate() - n);
+  return t;
 }
 
 /** KST 기준 오늘 날짜 문자열 YYYY-MM-DD */
 export function todayKSTString(): string {
-  return formatDate(todayKST());
+  return ymdKST();
 }
 
 // --- Legacy (하위 호환) ---


### PR DESCRIPTION
## Release v2.2.1

M2-8 (날짜/타임존 정합성 + 리포트 안정화)에서 발견된 후속 이슈 3건을 묶어 패치 릴리즈.

### 변경 사항

**🛡️ 미래 날짜 가드 (#88, PR #89)**
- `body-composition` fetcher: Garmin entry epoch ms가 미래 instant이면 skip

**🕐 KST instant 정확화 + 리포트 안정화 (#90, PR #91)**
- `utils.*KST` 함수 진짜 KST midnight UTC instant 반환 (Intl + ISO offset)
- `dateRange/formatDate/startOfDay`도 KST-aware로 통일 → fetcher 다운스트림까지 정합
- 리포트 재생성 시 `reportDate` 유지 (UI 재생성 버튼이 `record.reportDate` 명시 전달)
- API 가드: `reportDate`는 `force=true` + `morning/evening` + KST today/yesterday만 허용
- 텔레그램 cron 안전망: 단계별 로그(preSync/askAdvisor) + `sendToAll` 결과 검증 (sent=0이면 throw) + 실패 시 텔레그램 에러 알림

**🌐 잔여 KST 정합 (#92, PR #93)**
- `sleep` / `blood-pressure` fetcher: Garmin string에서 직접 `${date}T00:00:00+09:00` ISO offset Date
- `calorie-balance` `summaryKey`: ymdKST + ISO offset 기반

### 영향
- 서버 KST 환경 외형 동작 동일 (회귀 없음)
- UTC 등 타 TZ 호스트로 옮길 때 정합성 확보
- 텔레그램 리포트 미수신 시 사용자에게 즉시 에러 알림 도착
- 자정 넘김 (< 24h) 재생성 시 원본 record 갱신 보장

### Test plan
- [x] `npm run lint && npx tsc --noEmit && npm run build` 모두 통과
- [x] codex-cli + GitHub codex 다중 라운드 리뷰 통과 (P0/P1/P2 0건)
- [ ] 운영 환경 PM2 봇 재시작 후 다음 cron run에서 단계별 로그 + 도착 확인

### 별도 이슈로 분리 (백로그)
- `asOfDate`를 리포트 생성 파이프라인 전체(preSync/MCP/프롬프트)로 관통하여 진짜 과거 컨텍스트 재생성 지원