### PR TITLE
Release v2.2.2 — Dependabot 보안 패치 (next/axios/qs/hono)

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -241,3 +241,17 @@
 6. M4-6 (대시보드) — 복잡도 높음
 7. M4-7 ~ M4-10 — 순차 진행
 ```
+
+---
+
+# 유지보수 / 보안
+
+## Dependabot 보안 패치 2026-06 ✅
+
+- [x] next 16.2.4 → 16.2.9 (^16.2.6) — high 7 / med 4 / low 2 알림
+- [x] axios 1.15.1 → 1.17.0 (overrides ^1.16.0) — high 7 / med 1
+- [x] hono 4.12.14 → 4.12.25 (overrides ^4.12.21) — med 6 / low 1
+- [x] qs 6.15.0 → 6.15.2 (overrides ^6.15.2) — med 1
+- 효과: GitHub Dependabot open 알림 29건 → 0건
+- 스펙: `docs/specs/security-dependabot-202606.md` (#99, PR #100)
+

--- a/docs/specs/security-dependabot-202606.md
+++ b/docs/specs/security-dependabot-202606.md
@@ -1,0 +1,71 @@
+# Security: Dependabot 보안 패치 (2026-06)
+
+## 목적
+
+GitHub Dependabot 알림으로 보고된 npm 패키지 취약점 29건을 모두 해소.
+전부 npm 생태계, runtime/transitive 의존성. 비즈니스 로직 변경 없음.
+
+## 영향 패키지 및 패치 타겟
+
+| 패키지 | 현재 | 타겟 (resolved) | 알림 수 | 의존 형태 | 패치 방식 |
+|---|---|---|---|---|---|
+| `next` | 16.2.4 | `^16.2.6` (resolved **16.2.9**) | 13 (high 7 / med 4 / low 2) | direct | package.json dependency bump |
+| `axios` | 1.15.1 | `^1.16.0` (resolved **1.17.0**) | 8 (high 7 / med 1) | transitive (`@flow-js/garmin-connect`) | npm `overrides` |
+| `qs` | 6.15.0 | `^6.15.2` (resolved **6.15.2**) | 1 (med) | transitive (`@flow-js/garmin-connect`, `@modelcontextprotocol/sdk` → express) | npm `overrides` |
+| `hono` | 4.12.14 | `^4.12.21` (resolved **4.12.25**) | 7 (med 6 / low 1) | transitive (`@modelcontextprotocol/sdk`) | npm `overrides` |
+| `eslint-config-next` | 16.2.4 | `^16.2.6` (resolved 16.2.9) | (next와 동기) | devDep | bump |
+
+총 Dependabot open 알림: **29건 → 0건** 목표 (13 + 8 + 1 + 7 = 29).
+
+### Lockfile 부수 효과
+
+`axios 1.15.1 → 1.17.0` 갱신은 `https-proxy-agent@5.0.1`, `agent-base@6.0.2` transitive 의존을 lockfile에
+신규 추가한다 (axios 1.17 패치 라인의 정규 의존). 코드/런타임에서 axios 직접 import 없고 사용처는
+`@flow-js/garmin-connect` 1곳 한정이라 동작 영향 없음. 기록 목적으로 명시.
+
+## 요구사항
+
+- [ ] `package.json` 직접 의존: `next`, `eslint-config-next` `^16.2.6`로 bump
+- [ ] `package.json` `overrides` 추가: `axios ^1.16.0`, `qs ^6.15.2`, `hono ^4.12.21`
+- [ ] `npm install`로 lockfile 동기화
+- [ ] `npm ls axios qs hono next` 출력에서 모든 인스턴스가 패치 버전 이상
+- [ ] `npm run lint && npm run typecheck && npm run build` 통과
+- [ ] `gh api ... /dependabot/alerts` 상 open 알림 0건 (자동 종료 확인)
+- [ ] codex-cli 코드 리뷰 P1/P2 0건
+
+## 기술 설계
+
+### npm overrides
+
+`@flow-js/garmin-connect`(1.6.16)와 `@modelcontextprotocol/sdk`(1.29.0)는 우리가 제어 못하므로
+package.json overrides로 transitive 버전을 강제한다. 모두 minor/patch 범위라 API 호환.
+
+```json
+"overrides": {
+  "axios": "^1.16.0",
+  "qs": "^6.15.2",
+  "hono": "^4.12.21"
+}
+```
+
+### Next.js 16.2.4 → 16.2.6
+
+- 16.2.5: 다수 SSRF/middleware bypass/cache poisoning/XSS 패치
+- 16.2.6: segment-prefetch 경로 middleware bypass 후속 패치
+
+App Router를 사용 중이며 middleware 없음. CSP nonce 미사용. 그래도 의존성 자체를 패치된 버전으로
+올려 향후 추가 도입 시 안전 확보.
+
+## 테스트 계획
+
+1. `npm install` 후 `npm ls axios qs hono next` 확인
+2. `npm run lint && npm run typecheck && npm run build` 통과
+3. `npm audit --omit=dev` 출력에서 high/critical 0건 확인
+4. dev 서버 부팅 후 `/` 페이지 SSR 정상, `/api/sync` 호출 한 번 정상 확인은 PR 머지 후 실서버에서 수행
+
+## 제외 사항
+
+- 비즈니스 로직 변경 없음
+- DB 마이그레이션 없음
+- UI 변경 없음
+- garmin-connect upstream의 axios 버전 핀(SDK 의존) 변경은 upstream PR 영역으로 별도

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "dompurify": "^3.3.3",
         "grammy": "^1.42.0",
         "marked": "^17.0.6",
-        "next": "^16.2.4",
+        "next": "^16.2.6",
         "next-themes": "^0.4.6",
         "node-cron": "^4.2.1",
         "react": "^19.2.5",
@@ -33,7 +33,7 @@
         "dotenv": "^17.4.1",
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
-        "eslint-config-next": "^16.2.4",
+        "eslint-config-next": "^16.2.6",
         "postcss": "^8",
         "prisma": "^6.19.3",
         "tailwindcss": "^3.4.1",
@@ -1667,15 +1667,15 @@
       }
     },
     "node_modules/@next/env": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.4.tgz",
-      "integrity": "sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-16.2.9.tgz",
+      "integrity": "sha512-ki5VxxXfzD/9TDe13wyeTKIjQTAwBVpnr8KhRDUr8ltMUq1/NBpWNT5tiPoxiGl+PHM4X2ahSOiPk6iAimIzPg==",
       "license": "MIT"
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.4.tgz",
-      "integrity": "sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-16.2.9.tgz",
+      "integrity": "sha512-UZi8+YT/MLgTC9nrrn2Xd4lBYv1B7lVmtWHfPcthAI5Tt/C1LuDe6DfmtCtJ+WQod3ksY4VrKSvk3oMVAnL7qw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1713,9 +1713,9 @@
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.4.tgz",
-      "integrity": "sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-16.2.9.tgz",
+      "integrity": "sha512-HkfxNYUCmcct0Xsqib5KxqMSHV4AHJq857BNRchyBDs4YS19aHzVfn1kDuBYKqLLQBjXgnkIsjV2Kd4d2wzYhw==",
       "cpu": [
         "arm64"
       ],
@@ -1729,9 +1729,9 @@
       }
     },
     "node_modules/@next/swc-darwin-x64": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.4.tgz",
-      "integrity": "sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-16.2.9.tgz",
+      "integrity": "sha512-7IAtK4MeybpqRV9GRABWEhJ62mOS+rzWOzOTFie4cSEtm12xsoOMJRcECoZx3FHPzFAqN/IJtHqWAFOLfl152w==",
       "cpu": [
         "x64"
       ],
@@ -1745,9 +1745,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.4.tgz",
-      "integrity": "sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-16.2.9.tgz",
+      "integrity": "sha512-hBD75iWpUtkL9SmQmcRhmLomn9jgkPzCEkbOcLgHymPEKzv+6ONy13RRiIEz/iEObjkS2Jlb5gYS2XGoS3X4rw==",
       "cpu": [
         "arm64"
       ],
@@ -1761,9 +1761,9 @@
       }
     },
     "node_modules/@next/swc-linux-arm64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.4.tgz",
-      "integrity": "sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-16.2.9.tgz",
+      "integrity": "sha512-qZTI3pf9SGc/obr8NkQAekBxmp1QK+kVm+VAf3BALLfFAj+1kUhkTxmrWpVos9R/UYIA8AWX2p6cGI5WdwzVUA==",
       "cpu": [
         "arm64"
       ],
@@ -1777,9 +1777,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-gnu": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.4.tgz",
-      "integrity": "sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-16.2.9.tgz",
+      "integrity": "sha512-xm0HfRNX+UkH4R3c18ynswjj5o5uEj/7iI9p9omdtTSIsRCzQqkGMA+10nzJ4EHnYC3as65IMhbbl5fWRUWHYg==",
       "cpu": [
         "x64"
       ],
@@ -1793,9 +1793,9 @@
       }
     },
     "node_modules/@next/swc-linux-x64-musl": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.4.tgz",
-      "integrity": "sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-16.2.9.tgz",
+      "integrity": "sha512-QumimHkGEG6vM3PfEDWKyKen03NcqLOkeKB1EfcPe7VxzmEiCa4jNnMyBn/US5zcd/VE1CI+O8Ovb3lfjVHfGw==",
       "cpu": [
         "x64"
       ],
@@ -1809,9 +1809,9 @@
       }
     },
     "node_modules/@next/swc-win32-arm64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.4.tgz",
-      "integrity": "sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-16.2.9.tgz",
+      "integrity": "sha512-hzQpKZvw8rAwI6A2uQh6SacCSvNAXaIkPNsWwzqqfRiIMiXMfH936skDhz1OO6KpvdKkJrgHHtqQOq5PIXOvdQ==",
       "cpu": [
         "arm64"
       ],
@@ -1825,9 +1825,9 @@
       }
     },
     "node_modules/@next/swc-win32-x64-msvc": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.4.tgz",
-      "integrity": "sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-16.2.9.tgz",
+      "integrity": "sha512-qr2VL3Ce5QrwgO2yh1ujSBawrimjVKX8FGF/cOynmdYKJY0BdHpGVNIRK1tqONB10Vkm25Ub1BD2bkjWs4+96w==",
       "cpu": [
         "x64"
       ],
@@ -2790,6 +2790,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.14.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
@@ -3126,13 +3138,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.1.tgz",
-      "integrity": "sha512-WOG+Jj8ZOvR0a3rAn+Tuf1UQJRxw5venr6DgdbJzngJE3qG7X0kL83CZGpdHMxEm+ZK3seAbvFsw4FfOfP9vxg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -4433,13 +4446,13 @@
       }
     },
     "node_modules/eslint-config-next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.4.tgz",
-      "integrity": "sha512-A6ekXYFj/YQxBPMl45g3e+U8zJo+X2+ZQwcz34pPKjpc/3S4roBA2Rd9xWB4FKuSxhofo1/95WjzmUY+wHrOhg==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/eslint-config-next/-/eslint-config-next-16.2.9.tgz",
+      "integrity": "sha512-olGtBrs07bQchpaJWeqbk9GaMoU0oGmN/pYNEBXSbfgKngb5uHnPe37X6tVeh6DJfaWFQildvinGEOrolo5fmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "16.2.4",
+        "@next/eslint-plugin-next": "16.2.9",
         "eslint-import-resolver-node": "^0.3.6",
         "eslint-import-resolver-typescript": "^3.5.2",
         "eslint-plugin-import": "^2.32.0",
@@ -5585,9 +5598,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.14",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.14.tgz",
-      "integrity": "sha512-am5zfg3yu6sqn5yjKBNqhnTX7Cv+m00ox+7jbaKkrLMRJ4rAdldd1xPd/JzbBWspqaQv6RSTrgFN95EsfhC+7w==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -5611,6 +5624,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -6604,12 +6630,12 @@
       }
     },
     "node_modules/next": {
-      "version": "16.2.4",
-      "resolved": "https://registry.npmjs.org/next/-/next-16.2.4.tgz",
-      "integrity": "sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==",
+      "version": "16.2.9",
+      "resolved": "https://registry.npmjs.org/next/-/next-16.2.9.tgz",
+      "integrity": "sha512-MEOJiq/UvuezAdqVSceHbqDgZt1kDw2tpGVOlsdIoJsQdbN2JY2hpVG4xnXGkbdJUOEWhnRfiu/O4Hpc9Juwww==",
       "license": "MIT",
       "dependencies": {
-        "@next/env": "16.2.4",
+        "@next/env": "16.2.9",
         "@swc/helpers": "0.5.15",
         "baseline-browser-mapping": "^2.9.19",
         "caniuse-lite": "^1.0.30001579",
@@ -6623,14 +6649,14 @@
         "node": ">=20.9.0"
       },
       "optionalDependencies": {
-        "@next/swc-darwin-arm64": "16.2.4",
-        "@next/swc-darwin-x64": "16.2.4",
-        "@next/swc-linux-arm64-gnu": "16.2.4",
-        "@next/swc-linux-arm64-musl": "16.2.4",
-        "@next/swc-linux-x64-gnu": "16.2.4",
-        "@next/swc-linux-x64-musl": "16.2.4",
-        "@next/swc-win32-arm64-msvc": "16.2.4",
-        "@next/swc-win32-x64-msvc": "16.2.4",
+        "@next/swc-darwin-arm64": "16.2.9",
+        "@next/swc-darwin-x64": "16.2.9",
+        "@next/swc-linux-arm64-gnu": "16.2.9",
+        "@next/swc-linux-arm64-musl": "16.2.9",
+        "@next/swc-linux-x64-gnu": "16.2.9",
+        "@next/swc-linux-x64-musl": "16.2.9",
+        "@next/swc-win32-arm64-msvc": "16.2.9",
+        "@next/swc-win32-x64-msvc": "16.2.9",
         "sharp": "^0.34.5"
       },
       "peerDependencies": {
@@ -7448,9 +7474,9 @@
       "license": "MIT"
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "side-channel": "^1.1.0"

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "dompurify": "^3.3.3",
     "grammy": "^1.42.0",
     "marked": "^17.0.6",
-    "next": "^16.2.4",
+    "next": "^16.2.6",
     "next-themes": "^0.4.6",
     "node-cron": "^4.2.1",
     "react": "^19.2.5",
@@ -37,11 +37,16 @@
     "dotenv": "^17.4.1",
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
-    "eslint-config-next": "^16.2.4",
+    "eslint-config-next": "^16.2.6",
     "postcss": "^8",
     "prisma": "^6.19.3",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",
     "typescript": "^5"
+  },
+  "overrides": {
+    "axios": "^1.16.0",
+    "qs": "^6.15.2",
+    "hono": "^4.12.21"
   }
 }


### PR DESCRIPTION
## v2.2.2 패치 릴리즈

GitHub Dependabot open 보안 알림 29건 일괄 해소.

### 변경 패키지

| 패키지 | before → after | 알림 수 | 의존 형태 |
|---|---|---|---|
| `next` | 16.2.4 → 16.2.9 | 13 (high 7 / med 4 / low 2) | direct |
| `axios` | 1.15.1 → 1.17.0 | 8 (high 7 / med 1) | transitive |
| `hono` | 4.12.14 → 4.12.25 | 7 (med 6 / low 1) | transitive |
| `qs` | 6.15.0 → 6.15.2 | 1 (med) | transitive |

- 비즈니스 로직 / DB / UI 변경 없음
- transitive 의존은 `package.json` `overrides`로 강제
- 본 PR 머지 → Dependabot 재스캔 → 알림 29건 자동 close 예상

### 포함 변경

- #100 [Security] Dependabot 보안 패치 (#99)
- `docs/roadmap.md`: 유지보수/보안 섹션 신설 + 본 패치 표기

### 운영 액션 (머지 후)

```bash
pm2 restart myfitness-web myfitness-bot
```

### 체크리스트

- [x] dev에서 `npm run lint && typecheck && build` 통과
- [x] 코드 리뷰 통과 (GitHub @codex 봇 3 round + 로컬 code-reviewer, P1/P2 0건)
- [x] PR #100 머지 완료 → dev 반영
- [ ] main 머지 후 v2.2.2 태그 + GitHub Release