### PR TITLE
[Security] npm audit 후속 정합 — devDep + MCP transitive (#103)

### DIFF
--- a/docs/specs/security-audit-followup-202606.md
+++ b/docs/specs/security-audit-followup-202606.md
@@ -1,0 +1,64 @@
+# Security: npm audit 후속 정합 (2026-06)
+
+## 목적
+
+v2.2.2 (#100)에서 Dependabot 알림 29건 일괄 해소 후, `npm audit`이 추가로 보고하는
+6건(high 1 / moderate 5)을 마저 해소. Dependabot에는 등록되지 않은 항목으로 devDep 또는
+MCP SDK transitive가 대부분이지만 audit 출력을 클린 상태로 유지.
+
+## 영향 패키지 및 패치
+
+| 패키지 | before | after | 심각도 | 의존 형태 | 패치 방식 |
+|---|---|---|---|---|---|
+| `fast-uri` | 3.1.0 | `^3.1.2` (resolved 3.1.2) | **high** | transitive (`@modelcontextprotocol/sdk` → `ajv`) | overrides |
+| `ip-address` | 10.1.0 | `^10.1.1` (resolved 10.2.0) | moderate | transitive (mcp-sdk → `express-rate-limit`) | overrides |
+| `brace-expansion@5` | 5.0.5 | `^5.0.6` (resolved 5.0.6) | moderate | **devDep** (typescript-eslint → minimatch@10) | scoped overrides |
+| `postcss` (direct) | `^8` (8.5.8) | `^8.5.10` (resolved 8.5.15) | moderate | devDep | direct bump |
+| `postcss` (전체 트리) | 8.4.31 (next 번들) | `$postcss` (resolved 8.5.15) | (next via) | overrides |
+
+총 audit 보고: **6건 → 0건** (`npm audit` 출력 클린).
+
+### scoped 오버라이드 주의
+
+`brace-expansion`은 1.x / 2.x / 5.x가 공존: 5.x만 취약(GHSA-jxxr-4gwj-5jf2), 1.x는 영향 없음.
+1.x를 강제로 5.x로 올리면 legacy `minimatch@3.x`의 `require('brace-expansion')` 호출이
+`TypeError: expand is not a function`으로 깨짐. 따라서 npm overrides의 `pkg@<range>` scoped 문법으로
+**5.x만** 5.0.6+로 강제. 1.x는 자연스럽게 1.1.15(최신, 비취약)로 해소됨.
+
+```json
+"brace-expansion@5": "^5.0.6"
+```
+
+### `$postcss` self-reference
+
+`postcss`는 우리 직접 devDep + next 번들 + tailwindcss 의존이 모두 있는 다중 위치 패키지.
+직접 devDep을 `^8.5.10`으로 bump해도 next는 자체적으로 `postcss@8.4.31`을 끌고 옴.
+`"postcss": "$postcss"`는 npm overrides의 self-reference 문법으로 "모든 transitive postcss를
+직접 의존 resolved 버전과 동일하게 강제" — next 트리 안의 postcss도 8.5.15로 통일.
+
+## 요구사항
+
+- [x] `package.json`:
+  - `devDependencies.postcss` `^8` → `^8.5.10`
+  - `overrides`에 추가:
+    - `fast-uri: ^3.1.2`
+    - `ip-address: ^10.1.1`
+    - `brace-expansion@5: ^5.0.6` (scoped)
+    - `postcss: $postcss`
+- [x] `npm install` 후 `npm audit` 0 vulnerabilities
+- [x] `npm run lint && typecheck && build` 통과
+- [ ] 코드 리뷰 P1/P2 0건
+
+## 테스트 계획
+
+1. `npm install` → `npm audit` "found 0 vulnerabilities" 확인
+2. `npm ls brace-expansion` → 5.x만 5.0.6 overridden, 1.x는 1.1.15
+3. `npm ls postcss` → 전부 8.5.15
+4. lint / typecheck / build 전체 통과
+5. 머지 후 main → v2.2.3 패치 릴리즈
+
+## 제외
+
+- 비즈니스 로직 / DB / UI 변경 없음
+- 직접 의존 추가 없음 (postcss devDep만 minor 캐럿 조정)
+- next 다운그레이드 제안(`audit fix --force` → next@9.3.3) 무시 — postcss override로 동등 효과 + breaking 회피

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
         "esbuild": "^0.28.0",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.6",
-        "postcss": "^8",
+        "postcss": "^8.5.10",
         "prisma": "^6.19.3",
         "tailwindcss": "^3.4.1",
         "tsx": "^4.21.0",
@@ -821,9 +821,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -902,9 +902,9 @@
       "license": "MIT"
     },
     "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3219,9 +3219,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4480,9 +4480,9 @@
       "license": "MIT"
     },
     "node_modules/eslint-config-next/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4753,9 +4753,9 @@
       "license": "MIT"
     },
     "node_modules/eslint/node_modules/brace-expansion": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-      "integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5078,9 +5078,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -5733,9 +5733,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6580,9 +6580,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -6690,34 +6690,6 @@
       "peerDependencies": {
         "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
         "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-cron": {
@@ -7193,10 +7165,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
-      "dev": true,
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -7213,7 +7184,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "esbuild": "^0.28.0",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.6",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "prisma": "^6.19.3",
     "tailwindcss": "^3.4.1",
     "tsx": "^4.21.0",
@@ -47,6 +47,10 @@
   "overrides": {
     "axios": "^1.16.0",
     "qs": "^6.15.2",
-    "hono": "^4.12.21"
+    "hono": "^4.12.21",
+    "fast-uri": "^3.1.2",
+    "ip-address": "^10.1.1",
+    "brace-expansion@5": "^5.0.6",
+    "postcss": "$postcss"
   }
 }


### PR DESCRIPTION
## 변경 사항

v2.2.2 (PR #100)에서 Dependabot 29건 해소 후 잔여 `npm audit` 보고 **6건 → 0건**.

### 패키지 변경

| 패키지 | before | resolved | 심각도 | 위치 |
|---|---|---|---|---|
| `fast-uri` | 3.1.0 | 3.1.2 (overrides ^3.1.2) | **high** | mcp-sdk → ajv |
| `ip-address` | 10.1.0 | 10.2.0 (overrides ^10.1.1) | moderate | mcp-sdk → express-rate-limit |
| `brace-expansion@5` | 5.0.5 | 5.0.6 (scoped overrides) | moderate | typescript-eslint → minimatch@10 |
| `postcss` (direct) | ^8 → ^8.5.10 | 8.5.15 | moderate | devDep |
| `postcss` (next 번들) | 8.4.31 | 8.5.15 (overrides \"\$postcss\") | (next via) | next-internal |

### 디자인 노트

1. **`brace-expansion@5` scoped 강제**: 1.x도 함께 5.x로 끌어올리면 legacy `minimatch@3.x`가
   `require('brace-expansion')()` 호출에서 `TypeError: expand is not a function` 발생 (eslint
   런타임 깨짐). 따라서 5.x만 한정해서 패치. 1.x는 비취약이라 1.1.15로 자연 해소.
2. **`postcss: \$postcss` self-reference**: postcss는 직접 devDep + next 번들 + tailwindcss
   의존이 모두 있는 다중 위치. 직접 devDep만 올리면 next는 자체 8.4.31을 계속 들고 옴.
   `\$postcss`는 npm overrides의 self-reference 문법으로 모든 transitive 인스턴스를
   직접 의존 resolved 버전(8.5.15)으로 통일.

## 검증

- [x] `npm audit` → **found 0 vulnerabilities**
- [x] `npm run lint && typecheck && build` 전부 통과 (next + mcp + bot)
- [x] `npm ls brace-expansion` → 5.x만 5.0.6, 1.x는 1.1.15 유지
- [x] `npm ls postcss` → 전부 8.5.15

## 영향

- 비즈니스 로직 / DB / UI 변경 없음
- 직접 의존 변경: `postcss ^8 → ^8.5.10`만 (devDep)
- lockfile 자동 갱신

Closes #103

## 스펙

`docs/specs/security-audit-followup-202606.md`